### PR TITLE
A  pseudo PR about formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+- repo: https://github.com/doublify/pre-commit-rust
+  rev: v1.0
+  hooks:
+    - id: fmt
+      args: ['--verbose', '--', '--check']

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: all init init-deps
+
+all:
+
+init: init-deps
+	pre-commit install
+
+init-deps:
+	pip3 install pre-commit

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 If your are new for Ink! smart contract language, please head to [Parity Ink document](https://paritytech.github.io/ink/)
 or you can checkout our [PhatContract document](https://wiki.phala.network/en-us/build/general/intro/) for the details.
 
+## Initialize the project
+
+Run `make init` to initialize the project or make sure the project is properly configured.
+
 ## Compile contract
 
 This repo contains several contracts, each of them can be compiled and deployed individually, for example build `evm-chain`:

--- a/contracts/semi-bridge/src/lib.rs
+++ b/contracts/semi-bridge/src/lib.rs
@@ -6,14 +6,17 @@ use ink_lang as ink;
 
 #[ink::contract(env = pink_extension::PinkEnvironment)]
 mod semi_bridge {
-    use alloc::{string::String, string::ToString, vec::Vec};
-    use index::v0::prelude::*;
-    use index::v0::utils::ToArray;
+    use alloc::{
+        string::{String, ToString},
+        vec::Vec,
+    };
+    use index::v0::{prelude::*, utils::ToArray};
     use ink_storage::traits::{PackedLayout, SpreadLayout};
-    use pink_web3::ethabi::{Bytes, Uint};
-    use pink_web3::futures::executor;
-    use pink_web3::keys::pink::KeyPair;
-    use pink_web3::signing::Key;
+    use pink_web3::{
+        ethabi::{Bytes, Uint},
+        keys::pink::KeyPair,
+        signing::Key,
+    };
     use primitive_types::{H160, H256, U256};
     use scale::{Decode, Encode};
 
@@ -63,12 +66,14 @@ mod semi_bridge {
 
         /// Configures the bridge
         #[ink(message)]
-        pub fn config(&mut self, rpc: String, bridge_address: H160) -> Result<()> {
+        pub fn config(
+            &mut self,
+            rpc: String,
+            bridge_address: H160,
+        ) -> Result<()> {
             self.ensure_owner()?;
-            self.config = Some(Config {
-                rpc,
-                bridge_address: bridge_address.into(),
-            });
+            self.config =
+                Some(Config { rpc, bridge_address: bridge_address.into() });
             Ok(())
         }
 
@@ -109,11 +114,7 @@ mod semi_bridge {
         /// * `token_rid`: token resource id
         /// * `amount`: amount of token to be transferred
         #[ink(message)]
-        pub fn transfer(
-            &self,
-            token_rid: H256,
-            amount: U256,
-        ) -> Result<()> {
+        pub fn transfer(&self, token_rid: H256, amount: U256) -> Result<()> {
             let config = self
                 .config
                 .as_ref()
@@ -142,9 +143,11 @@ mod semi_bridge {
             dotenv().ok();
 
             pink_extension_runtime::mock_ext::mock_all_ext();
-            pink_extension::chain_extension::mock::mock_derive_sr25519_key(|_| {
-                hex!["4c5d4f158b3d691328a1237d550748e019fe499ebf3df7467db6fa02a0818821"].to_vec()
-            });
+            pink_extension::chain_extension::mock::mock_derive_sr25519_key(
+                |_| {
+                    hex!["4c5d4f158b3d691328a1237d550748e019fe499ebf3df7467db6fa02a0818821"].to_vec()
+                },
+            );
 
             // Register contracts
             let hash1 = ink_env::Hash::try_from([10u8; 32]).unwrap();
@@ -164,7 +167,8 @@ mod semi_bridge {
                 hex!("056c0e37d026f9639313c281250ca932c9dbe921").into();
 
             bridge.config(rpc, bridge_contract_addr).unwrap();
-            let secret_key = std::env::vars().find(|x| x.0 == "SECRET_KEY").unwrap().1;
+            let secret_key =
+                std::env::vars().find(|x| x.0 == "SECRET_KEY").unwrap().1;
             let secret_bytes = hex::decode(secret_key).unwrap();
             bridge.set_account(secret_bytes);
 

--- a/index/src/lib.rs
+++ b/index/src/lib.rs
@@ -1,6 +1,4 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 extern crate alloc;
 
-
 pub mod v0;
-

--- a/index/src/v0/executors/bridge_executor.rs
+++ b/index/src/v0/executors/bridge_executor.rs
@@ -1,10 +1,14 @@
-use crate::v0::traits::{Address, Error, Executor};
-use crate::v0::transactors::EvmContractClient;
+use crate::v0::{
+    traits::{Address, Error, Executor},
+    transactors::EvmContractClient,
+};
 use alloc::vec::Vec;
-use pink_web3::api::{Eth, Namespace};
-use pink_web3::contract::Contract;
-use pink_web3::keys::pink::KeyPair;
-use pink_web3::transports::{resolve_ready, PinkHttp};
+use pink_web3::{
+    api::{Eth, Namespace},
+    contract::Contract,
+    keys::pink::KeyPair,
+    transports::{resolve_ready, PinkHttp},
+};
 use primitive_types::{H160, H256, U256};
 
 pub struct Evm2PhalaExecutor {
@@ -21,7 +25,8 @@ impl Executor for Evm2PhalaExecutor {
         if let Address::EthAddr(address) = bridge_address {
             Ok(Self {
                 bridge_contract: EvmContractClient {
-                    contract: Contract::from_json(eth, address, abi_json).or(Err(Error::BadAbi))?,
+                    contract: Contract::from_json(eth, address, abi_json)
+                        .or(Err(Error::BadAbi))?,
                 },
             })
         } else {
@@ -42,9 +47,12 @@ impl Executor for Evm2PhalaExecutor {
         // for now we just concatenate `0x00010100` to a hardcoded one
         let recipient_address: Vec<u8> =
             hex!("000101008eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48").into();
-        _ = self
-            .bridge_contract
-            .deposit(signer, token_rid, amount, recipient_address)?;
+        _ = self.bridge_contract.deposit(
+            signer,
+            token_rid,
+            amount,
+            recipient_address,
+        )?;
         Ok(())
     }
 }

--- a/index/src/v0/mod.rs
+++ b/index/src/v0/mod.rs
@@ -1,5 +1,5 @@
-mod traits;
 pub mod executors;
-pub mod utils;
 pub mod prelude;
+mod traits;
 mod transactors;
+pub mod utils;

--- a/index/src/v0/prelude.rs
+++ b/index/src/v0/prelude.rs
@@ -1,3 +1,4 @@
-pub type Evm2PhalaExecutor = super::executors::bridge_executor::Evm2PhalaExecutor;
+pub type Evm2PhalaExecutor =
+    super::executors::bridge_executor::Evm2PhalaExecutor;
 pub use super::traits::Executor;
 pub type Address = super::traits::Address;

--- a/index/src/v0/transactors/evm_transactor.rs
+++ b/index/src/v0/transactors/evm_transactor.rs
@@ -1,13 +1,14 @@
 use crate::v0::traits::Error;
 use alloc::string::String;
-use pink_web3::api::{Eth, Namespace};
-use pink_web3::contract::tokens::Tokenize;
-use pink_web3::contract::{Contract, Options};
-use pink_web3::ethabi::{Bytes, Token, Uint};
-use pink_web3::keys::pink::KeyPair;
-use pink_web3::signing::Key;
-use pink_web3::transports::{resolve_ready, PinkHttp};
-use pink_web3::types::{Res, H160, H256};
+use pink_web3::{
+    api::{Eth, Namespace},
+    contract::{tokens::Tokenize, Contract, Options},
+    ethabi::{Bytes, Token, Uint},
+    keys::pink::KeyPair,
+    signing::Key,
+    transports::{resolve_ready, PinkHttp},
+    types::{Res, H160, H256},
+};
 
 /// The client to submit transaction to the Evm evm_contract contract
 pub struct EvmContractClient {

--- a/index/src/v1/traits/Cargo.toml
+++ b/index/src/v1/traits/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "traits"
+version = "0.1.0"
+authors = ["Wenfeng Wang <kalot.wang@gmail.com>"]
+edition = "2021"
+
+[dependencies]
+ink_primitives = { version = "3.3.1", default-features = false }
+ink_metadata = { version = "3.3.1", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.3.1", default-features = false }
+ink_storage = { version = "3.3.1", default-features = false }
+ink_lang = { version = "3.3.1", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "3.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.1", default-features = false, features = ["derive"], optional = true }
+
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
+xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29", default-features = false }
+
+pink-extension = { version = "0.1", default-features = false, features = ["ink-as-dependency"] }
+
+[lib]
+name = "traits"
+path = "lib.rs"
+crate-type = [
+	# Used for normal contract Wasm blobs.
+	"cdylib",
+    # Used for ABI generation.
+    "rlib",
+]
+
+[features]
+default = ["std"]
+std = [
+    "ink_metadata/std",
+    "ink_env/std",
+    "ink_storage/std",
+    "ink_primitives/std",
+    "sp-io/std",
+    "xcm/std",
+    "scale/std",
+    "scale-info/std",
+    "pink-extension/std",
+]
+ink-as-dependency = []

--- a/index/src/v1/traits/executor.rs
+++ b/index/src/v1/traits/executor.rs
@@ -10,17 +10,7 @@ use scale::{Decode, Encode};
 use xcm::latest::{AssetId, MultiLocation};
 
 /// Definition of source edge
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    scale::Encode,
-    scale::Decode,
-    SpreadLayout,
-    PackedLayout,
-    SpreadAllocate,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, scale::Encode, scale::Decode, SpreadLayout, PackedLayout)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout,))]
 pub struct SourceEdge {
     /// asset/chain
@@ -34,17 +24,7 @@ pub struct SourceEdge {
 }
 
 /// Definition of SINK edge
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    scale::Encode,
-    scale::Decode,
-    SpreadLayout,
-    PackedLayout,
-    SpreadAllocate,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, scale::Encode, scale::Decode, SpreadLayout, PackedLayout)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout,))]
 pub struct SinkEdge {
     /// asset/chain
@@ -58,17 +38,7 @@ pub struct SinkEdge {
 }
 
 /// Definition of swap operation edge
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    scale::Encode,
-    scale::Decode,
-    SpreadLayout,
-    PackedLayout,
-    SpreadAllocate,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, scale::Encode, scale::Decode, SpreadLayout, PackedLayout)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout,))]
 pub struct SwapEdge {
     /// asset/chain
@@ -92,17 +62,7 @@ pub struct SwapEdge {
 }
 
 /// Definition of bridge operation edge
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    scale::Encode,
-    scale::Decode,
-    SpreadLayout,
-    PackedLayout,
-    SpreadAllocate,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, scale::Encode, scale::Decode, SpreadLayout, PackedLayout)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout,))]
 pub struct BridgeEdge {
     /// asset/chain
@@ -121,7 +81,7 @@ pub struct BridgeEdge {
     b1: Option<u128>,
 }
 
-#[derive(Debug, PartialEq, Eq, scale::Encode, scale::Decode, SpreadLayout, PackedLayout)]
+#[derive(Clone, Debug, PartialEq, Eq, scale::Encode, scale::Decode, SpreadLayout, PackedLayout)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout,))]
 enum EdgeStatus {
     /// Haven't started executing this edge yet, which is the default status.
@@ -136,7 +96,7 @@ enum EdgeStatus {
     Confirmed(u128),
 }
 
-#[derive(Debug, PartialEq, Eq, scale::Encode, scale::Decode, SpreadLayout, PackedLayout)]
+#[derive(Clone, Debug, PartialEq, Eq, scale::Encode, scale::Decode, SpreadLayout, PackedLayout)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout,))]
 pub enum EdgeMeta {
     SourceEdge(SourceEdge),
@@ -145,17 +105,7 @@ pub enum EdgeMeta {
     BridgeEdge(BridgeEdge),
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    scale::Encode,
-    scale::Decode,
-    SpreadLayout,
-    PackedLayout,
-    SpreadAllocate,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, scale::Encode, scale::Decode, SpreadLayout, PackedLayout)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout,))]
 pub struct Edge {
     /// Content of the edge
@@ -170,17 +120,7 @@ pub struct Edge {
     nonce: Option<u128>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    scale::Encode,
-    scale::Decode,
-    SpreadLayout,
-    PackedLayout,
-    SpreadAllocate,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, scale::Encode, scale::Decode, SpreadLayout, PackedLayout)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout,))]
 pub struct Solution {
     /// All edges to included in the solution

--- a/index/src/v1/traits/lib.rs
+++ b/index/src/v1/traits/lib.rs
@@ -1,0 +1,17 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
+
+pub mod executor;
+pub mod registry;
+
+/// Evaluate `$x:expr` and if not true return `Err($y:expr)`.
+///
+/// Used as `ensure!(expression_to_ensure, expression_to_return_on_false)`.
+#[macro_export]
+macro_rules! ensure {
+    ( $condition:expr, $error:expr $(,)? ) => {{
+        if !$condition {
+            return ::core::result::Result::Err(::core::convert::Into::into($error));
+        }
+    }};
+}

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,24 @@
+# Basic
+hard_tabs = true
+max_width = 100
+use_small_heuristics = "Max"
+# Imports
+imports_granularity = "Crate"
+reorder_imports = true
+# Consistency
+newline_style = "Unix"
+# Misc
+chain_width = 80
+spaces_around_ranges = false
+binop_separator = "Back"
+reorder_impl_items = false
+match_arm_leading_pipes = "Preserve"
+match_arm_blocks = false
+match_block_trailing_comma = true
+trailing_comma = "Vertical"
+trailing_semicolon = false
+use_field_init_shorthand = true
+ignore = [
+    "bridges",
+]
+edition = "2021"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,24 +1,61 @@
+# Rust code formatting configurations
+## https://github.com/rust-lang/rustfmt/blob/master/Configurations
+
 # Basic
-hard_tabs = true
-max_width = 100
+## Use spaces for indention
+hard_tabs = false
+## maximum line width
+max_width = 80
+## this option configures a set of other options:
+##   - fn_call_width
+##   - attr_fn_like_width
+##   - struct_lit_width
+##   - struct_variant_width
+##   - array_width
+##   - chain_width
+##   - single_line_if_else_max_width
+## "Max" means all the options in the set is set to `max_width
 use_small_heuristics = "Max"
+
 # Imports
+## Controls how imports are structured in use statements
 imports_granularity = "Crate"
+## Reorder import and extern crate statements 
+##  alphabetically in groups 
+##  (a group is separated by a newline)
 reorder_imports = true
+
 # Consistency
+## Unix or Windows line endings
 newline_style = "Unix"
+
 # Misc
+## Maximum width of a chain to fit on one line.
 chain_width = 80
+## Put spaces around the .., ..=, and ... range operators
 spaces_around_ranges = false
+## Where to put a binary operator when a binary expression goes multiline.
 binop_separator = "Back"
+## Reorder impl items. type and const are put first, then macros and methods.
 reorder_impl_items = false
+## Controls whether to include a leading pipe on match arms
 match_arm_leading_pipes = "Preserve"
+## Controls whether arm bodies are wrapped 
+##  in cases where the first line of the body cannot fit on the same line 
+##  as the => operator.
 match_arm_blocks = false
+## Put a trailing comma after a block based match arm 
+##  (non-block arms are not affected)
 match_block_trailing_comma = true
+## How to handle trailing commas for lists
 trailing_comma = "Vertical"
+## Add trailing semicolon after break, continue and return
 trailing_semicolon = false
+## Use field initialize shorthand if possible.
 use_field_init_shorthand = true
+## Skip formatting files and directories that match the specified pattern
 ignore = [
-    "bridges",
+    # "src/types.rs"
 ]
+## Specifies which edition is used by the parser.
 edition = "2021"


### PR DESCRIPTION
Want to hear your opinions about the `rustfmt.toml`

Last week we talked about Rust code formatting, so I did some brief research on that, I looked into some famous codebases, here is what I found:

- Zero configuration
    - tokio: https://github.com/tokio-rs/tokio
- minimalist style
    - https://github.com/briansmith/ring/blob/main/rustfmt.toml
- Polkadot style
    - https://github.com/paritytech/polkadot/blob/master/rustfmt.toml
    - https://github.com/paritytech/substrate/blob/master/rustfmt.toml
- heavy
    - https://github.com/paritytech/subxt/blob/master/.rustfmt.toml

My thoughts:
1. if we are going to do this, we have to think about what will happen to the old code previously written
    - possible solutions:
       - when it comes to editing existing code, first format it and make a commit, then add new content
       - apply the formatting to the whole project in one commit
2. we should follow the Polkadot style
    - with the following exceptions:
        - no tabs for indentation
        - maximum line width should be 80, best for double panel editing on a 27-inch screen, with no code overflowing to the right





