### PR TITLE
Fetch task (user request with solution) from EVM chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,9 +1263,11 @@ dependencies = [
  "phat_offchain_rollup",
  "pink-extension 0.2.0",
  "pink-extension-runtime",
+ "pink-json 0.4.0 (git+https://github.com/Phala-Network/pink-json.git?branch=pink)",
  "pink-web3 0.19.4 (git+https://github.com/Phala-Network/pink-web3.git?branch=pink)",
  "primitive-types",
  "scale-info",
+ "serde",
  "xcm",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "az"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+
+[[package]]
 name = "backtrace"
 version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +256,12 @@ name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+
+[[package]]
+name = "bytemuck"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaa3a8d9a1ca92e282c96a32d6511b695d7d994d1d102ba85d279f9b2756947f"
 
 [[package]]
 name = "byteorder"
@@ -690,6 +702,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixed"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1965703169d4c3581f1d853e6a0bacf2ad9ba5d161f58ac331de95b37584a50"
+dependencies = [
+ "az",
+ "bytemuck",
+ "half",
+ "serde",
+ "typenum",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,6 +1013,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6a9459c9c30b177b925162351f97e7d967c7ea8bab3b8352805327daf45554"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "hash-db"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,6 +1282,7 @@ version = "0.1.0"
 dependencies = [
  "dotenv",
  "dyn-clone",
+ "fixed",
  "hex",
  "hex-literal",
  "index",

--- a/contracts/index_executor/Cargo.toml
+++ b/contracts/index_executor/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://phala.network/"
 repository = "https://github.com/Phala-Network/index-contract"
 
 [dependencies]
+serde = { version = "1.0.140", default-features = false, features = ["derive", "alloc"]}
 dyn-clone = "1.0.10"
 hex-literal = "0.3"
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
@@ -27,6 +28,7 @@ kv-session = { git = "https://github.com/Phala-Network/phat-offchain-rollup.git"
 
 pink-extension = { version = "0.2.0", default-features = false }
 pink-web3 = { git = "https://github.com/Phala-Network/pink-web3.git", branch = "pink", default-features = false, features = ["pink"]}
+pink-json = { git = "https://github.com/Phala-Network/pink-json.git", branch = "pink", default-features = false }
 
 index = { path = "../../index", default-features = false }
 index_registry = { path = "../index_registry", default-features = false, features = ["ink-as-dependency"] }
@@ -67,6 +69,7 @@ std = [
     "phat_offchain_rollup/std",
     "pink-extension/std",
     "pink-web3/std",
+    "pink-json/std",
     "index/std",
     "index_registry/std",
 ]

--- a/contracts/index_executor/Cargo.toml
+++ b/contracts/index_executor/Cargo.toml
@@ -12,6 +12,7 @@ serde = { version = "1.0.140", default-features = false, features = ["derive", "
 dyn-clone = "1.0.10"
 hex-literal = "0.3"
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
+fixed = { version = "1", default-features = false, features = ["serde"] }
 ink_primitives = { version = "3", default-features = false }
 ink_metadata = { version = "3", default-features = false, features = ["derive"], optional = true }
 ink_env = { version = "3", default-features = false }
@@ -28,7 +29,7 @@ kv-session = { git = "https://github.com/Phala-Network/phat-offchain-rollup.git"
 
 pink-extension = { version = "0.2.0", default-features = false }
 pink-web3 = { git = "https://github.com/Phala-Network/pink-web3.git", branch = "pink", default-features = false, features = ["pink"]}
-pink-json = { git = "https://github.com/Phala-Network/pink-json.git", branch = "pink", default-features = false }
+pink-json = { git = "https://github.com/Phala-Network/pink-json.git", branch = "pink", default-features = false, features = ["custom-error-messages"] }
 
 index = { path = "../../index", default-features = false }
 index_registry = { path = "../index_registry", default-features = false, features = ["ink-as-dependency"] }

--- a/contracts/index_executor/src/abi/handler.json
+++ b/contracts/index_executor/src/abi/handler.json
@@ -1,384 +1,398 @@
 [
-    {
-      "inputs": [],
-      "stateMutability": "nonpayable",
-      "type": "constructor"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "executor",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "worker",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "bytes32",
-          "name": "taskId",
-          "type": "bytes32"
-        }
-      ],
-      "name": "Claimed",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "sender",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "token",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        },
-        {
-          "indexed": false,
-          "internalType": "bytes",
-          "name": "recipient",
-          "type": "bytes"
-        },
-        {
-          "indexed": false,
-          "internalType": "bytes",
-          "name": "task",
-          "type": "bytes"
-        }
-      ],
-      "name": "Deposited",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "previousOwner",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "newOwner",
-          "type": "address"
-        }
-      ],
-      "name": "OwnershipTransferred",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "account",
-          "type": "address"
-        }
-      ],
-      "name": "Paused",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "account",
-          "type": "address"
-        }
-      ],
-      "name": "Unpaused",
-      "type": "event"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "name": "_activedTasks",
-      "outputs": [
-        {
-          "internalType": "bytes32",
-          "name": "",
-          "type": "bytes32"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "",
-          "type": "bytes32"
-        }
-      ],
-      "name": "_depositRecords",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "sender",
-          "type": "address"
-        },
-        {
-          "internalType": "contract IERC20",
-          "name": "token",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        },
-        {
-          "internalType": "bytes",
-          "name": "recipient",
-          "type": "bytes"
-        },
-        {
-          "internalType": "bytes",
-          "name": "task",
-          "type": "bytes"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "name": "_executors",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "worker",
-          "type": "address"
-        }
-      ],
-      "name": "claim",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "token",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        },
-        {
-          "internalType": "bytes",
-          "name": "recipient",
-          "type": "bytes"
-        },
-        {
-          "internalType": "address",
-          "name": "worker",
-          "type": "address"
-        },
-        {
-          "internalType": "bytes32",
-          "name": "taskId",
-          "type": "bytes32"
-        },
-        {
-          "internalType": "bytes",
-          "name": "task",
-          "type": "bytes"
-        }
-      ],
-      "name": "deposit",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "worker",
-          "type": "address"
-        }
-      ],
-      "name": "getActivedTasks",
-      "outputs": [
-        {
-          "internalType": "bytes32[]",
-          "name": "",
-          "type": "bytes32[]"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "taskId",
-          "type": "bytes32"
-        }
-      ],
-      "name": "getTaskData",
-      "outputs": [
-        {
-          "components": [
-            {
-              "internalType": "address",
-              "name": "sender",
-              "type": "address"
-            },
-            {
-              "internalType": "contract IERC20",
-              "name": "token",
-              "type": "address"
-            },
-            {
-              "internalType": "uint256",
-              "name": "amount",
-              "type": "uint256"
-            },
-            {
-              "internalType": "bytes",
-              "name": "recipient",
-              "type": "bytes"
-            },
-            {
-              "internalType": "bytes",
-              "name": "task",
-              "type": "bytes"
-            }
-          ],
-          "internalType": "struct Aggregator.DepositInfo",
-          "name": "",
-          "type": "tuple"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "owner",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "paused",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "executor",
-          "type": "address"
-        }
-      ],
-      "name": "removeExecutor",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "renounceOwnership",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "executor",
-          "type": "address"
-        }
-      ],
-      "name": "setExecutor",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "newOwner",
-          "type": "address"
-        }
-      ],
-      "name": "transferOwnership",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    }
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "worker",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "requestId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "Claimed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "recipient",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "request",
+        "type": "string"
+      }
+    ],
+    "name": "Deposited",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "_activedRequests",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "_depositRecords",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "recipient",
+        "type": "bytes"
+      },
+      {
+        "internalType": "string",
+        "name": "request",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "_workers",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "claim",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "claim_all",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "recipient",
+        "type": "bytes"
+      },
+      {
+        "internalType": "address",
+        "name": "worker",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "requestId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "string",
+        "name": "request",
+        "type": "string"
+      }
+    ],
+    "name": "deposit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "worker",
+        "type": "address"
+      }
+    ],
+    "name": "getActivedRequests",
+    "outputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "",
+        "type": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "worker",
+        "type": "address"
+      }
+    ],
+    "name": "getLastActivedRequest",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "requestId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRequestData",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IERC20",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "recipient",
+            "type": "bytes"
+          },
+          {
+            "internalType": "string",
+            "name": "request",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct Handler.DepositInfo",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "worker",
+        "type": "address"
+      }
+    ],
+    "name": "removeWorker",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "worker",
+        "type": "address"
+      }
+    ],
+    "name": "setWorker",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
 ]

--- a/contracts/index_executor/src/bridge.rs
+++ b/contracts/index_executor/src/bridge.rs
@@ -10,27 +10,27 @@ use scale::{Decode, Encode};
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
 pub struct BridgeStep {
     /// Asset id on source chain
-    from: Vec<u8>,
+    pub from: Vec<u8>,
     /// Name of source chain
-    source_chain: String,
+    pub source_chain: String,
     /// Asset on dest chain
-    to: Vec<u8>,
+    pub to: Vec<u8>,
     /// Name of dest chain
-    dest_chain: String,
+    pub dest_chain: String,
     /// Fee of the bridge represented by the transfer asset
-    fee: u128,
+    pub fee: u128,
     /// Capacity of the step
-    cap: u128,
+    pub cap: u128,
     /// Flow of the step
-    flow: u128,
+    pub flow: u128,
     /// Original relayer account balance of asset on source chain
     /// Should be set when initializing task
-    b0: Option<u128>,
+    pub b0: Option<u128>,
     /// Original relayer account balance of asset on dest chain
     /// Should be set when initializing task
-    b1: Option<u128>,
+    pub b1: Option<u128>,
     /// Bridge amount
-    amount: u128,
+    pub amount: u128,
 }
 
 impl Runner for BridgeStep {

--- a/contracts/index_executor/src/claimer.rs
+++ b/contracts/index_executor/src/claimer.rs
@@ -22,7 +22,7 @@ use serde::Deserialize;
 
 /// Call method `claim` of contract/pallet through RPC to claim the actived tasks
 /// For example, call RPC method defined here:
-///     https://github.com/Phala-Network/index-solidity/blob/07584ede4d6631c97dabc9ba52509c36d4fceb5b/contracts/Aggregator.sol#L63
+///     https://github.com/Phala-Network/index-solidity/blob/7b4458f9b8277df8a1c705a4d0f264476f42fcf2/contracts/Handler.sol#L108
 ///
 /// Return account nonce that related to this transaction
 #[derive(Clone, Decode, Encode, Eq, PartialEq, Ord, PartialOrd, Debug)]
@@ -74,8 +74,8 @@ impl ClaimStep {
 /// Fetch actived requests from blockchains and construct a `Task` from it.
 /// If the given chain is EVM based, fetch requests from solidity-based smart contract storage through RPC request.
 /// For example, call RPC methods defined here:
-///     https://github.com/Phala-Network/index-solidity/blob/07584ede4d6631c97dabc9ba52509c36d4fceb5b/contracts/Aggregator.sol#L70
-///     https://github.com/Phala-Network/index-solidity/blob/07584ede4d6631c97dabc9ba52509c36d4fceb5b/contracts/Aggregator.sol#L74
+///     https://github.com/Phala-Network/index-solidity/blob/7b4458f9b8277df8a1c705a4d0f264476f42fcf2/contracts/Handler.sol#L147
+///     https://github.com/Phala-Network/index-solidity/blob/7b4458f9b8277df8a1c705a4d0f264476f42fcf2/contracts/Handler.sol#L165
 /// If the given chain is Substrate based, fetch requests from pallet storage through RPC request.
 pub struct ActivedTaskFetcher {
     chain: Chain,

--- a/contracts/index_executor/src/claimer.rs
+++ b/contracts/index_executor/src/claimer.rs
@@ -1,11 +1,24 @@
-use alloc::string::String;
+use alloc::{string::String, vec::Vec};
 use index::graph::{Chain, ChainType};
 use scale::{Decode, Encode};
 
 use super::account::AccountInfo;
+use super::bridge::BridgeStep;
 use super::context::Context;
+use super::step::{Step, StepMeta};
+use super::swap::SwapStep;
 use super::task::{Task, TaskId};
 use super::traits::Runner;
+use hex_literal::hex;
+use pink_web3::{
+    api::{Eth, Namespace},
+    contract::{tokens::Detokenize, Contract, Error as PinkError, Options},
+    ethabi::Token,
+    transports::{resolve_ready, PinkHttp},
+    types::Address,
+};
+use primitive_types::{H160, U256};
+use serde::Deserialize;
 
 /// Call method `claim` of contract/pallet through RPC to claim the actived tasks
 /// For example, call RPC method defined here:
@@ -16,9 +29,9 @@ use super::traits::Runner;
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
 pub struct ClaimStep {
     /// Chain name
-    chain: String,
+    pub chain: String,
     /// Task Id
-    id: TaskId,
+    pub id: TaskId,
 }
 
 impl Runner for ClaimStep {
@@ -58,12 +71,12 @@ impl ClaimStep {
     }
 }
 
-/// Fetch actived tasks from blockchains.
-/// If the given chain is EVM based, fetch tasks from solidity-based smart contract storage through RPC request.
+/// Fetch actived requests from blockchains and construct a `Task` from it.
+/// If the given chain is EVM based, fetch requests from solidity-based smart contract storage through RPC request.
 /// For example, call RPC methods defined here:
 ///     https://github.com/Phala-Network/index-solidity/blob/07584ede4d6631c97dabc9ba52509c36d4fceb5b/contracts/Aggregator.sol#L70
 ///     https://github.com/Phala-Network/index-solidity/blob/07584ede4d6631c97dabc9ba52509c36d4fceb5b/contracts/Aggregator.sol#L74
-/// If the given chain is Substrate based, fetch tasks from pallet storage through RPC request.
+/// If the given chain is Substrate based, fetch requests from pallet storage through RPC request.
 pub struct ActivedTaskFetcher {
     chain: Chain,
     worker: AccountInfo,
@@ -75,18 +88,245 @@ impl ActivedTaskFetcher {
 
     pub fn fetch_task(&self) -> Result<Task, &'static str> {
         match self.chain.chain_type {
-            ChainType::Evm => {
-                Ok(self.query_evm_actived_tasks(self.chain.endpoint.clone(), &self.worker)?)
-            }
+            ChainType::Evm => Ok(self.query_evm_actived_request(&self.chain, &self.worker)?),
             ChainType::Sub => Err("Unimplemented"),
         }
     }
 
-    fn query_evm_actived_tasks(
+    fn query_evm_actived_request(
         &self,
-        _endpoint: String,
-        _worker: &AccountInfo,
+        chain: &Chain,
+        worker: &AccountInfo,
     ) -> Result<Task, &'static str> {
-        Err("Unimplemented")
+        let handler_on_goerli: H160 = hex!("bEA1C40ecf9c4603ec25264860B9b6623Ff733F5").into();
+        let transport = Eth::new(PinkHttp::new(&chain.endpoint));
+        let handler = Contract::from_json(
+            transport,
+            // TODO: use handler from ChainInfo
+            handler_on_goerli,
+            include_bytes!("./abi/handler.json"),
+        )
+        .map_err(|_| "ConstructContractFailed")?;
+        let worker_address: Address = worker.account20.into();
+        let request_id: [u8; 32] = resolve_ready(handler.query(
+            "getLastActivedRequest",
+            worker_address,
+            None,
+            Options::default(),
+            None,
+        ))
+        .unwrap();
+        let deposit_data: DepositData = resolve_ready(handler.query(
+            "getRequestData",
+            request_id.clone(),
+            None,
+            Options::default(),
+            None,
+        ))
+        .unwrap();
+        println!("deposit data: {:?}", &deposit_data);
+        deposit_data.to_task(&chain.name, request_id)
+    }
+}
+
+// Define the structures to parse deposit data json
+#[derive(Debug)]
+struct DepositData {
+    sender: Address,
+    token: Address,
+    amount: U256,
+    recipient: Vec<u8>,
+    request: String,
+}
+
+impl Detokenize for DepositData {
+    fn from_tokens(tokens: Vec<Token>) -> std::result::Result<Self, PinkError>
+    where
+        Self: Sized,
+    {
+        if tokens.len() == 1 {
+            let deposit_raw = tokens[0].clone();
+            match deposit_raw {
+                Token::Tuple(deposit_data) => {
+                    match (
+                        deposit_data[0].clone(),
+                        deposit_data[1].clone(),
+                        deposit_data[2].clone(),
+                        deposit_data[3].clone(),
+                        deposit_data[4].clone(),
+                    ) {
+                        (
+                            Token::Address(sender),
+                            Token::Address(token),
+                            Token::Uint(amount),
+                            Token::Bytes(recipient),
+                            Token::String(request),
+                        ) => Ok(DepositData {
+                            sender,
+                            token,
+                            amount,
+                            recipient,
+                            request,
+                        }),
+                        _ => Err(PinkError::InvalidOutputType(String::from(
+                            "Return type dismatch",
+                        ))),
+                    }
+                }
+                _ => Err(PinkError::InvalidOutputType(String::from(
+                    "Unexpected output type",
+                ))),
+            }
+        } else {
+            Err(PinkError::InvalidOutputType(String::from("Invalid length")))
+        }
+    }
+}
+
+impl DepositData {
+    fn to_task(&self, source_chain: &String, id: [u8; 32]) -> Result<Task, &'static str> {
+        let mut uninitialized_task: Task = Default::default();
+        println!("request data: {:?}", &self.request);
+        let request_data_json: RequestData =
+            pink_json::from_str(&self.request).map_err(|_| "Request data parse failed")?;
+        uninitialized_task.id = id.into();
+        // Preset
+        uninitialized_task.source = source_chain.clone();
+        uninitialized_task.sender = self.sender.as_bytes().into();
+        uninitialized_task.recipient = self.recipient.clone();
+        // Insert claim step
+        uninitialized_task.steps.push(Step {
+            meta: StepMeta::Claim(ClaimStep {
+                chain: source_chain.clone(),
+                id: id.into(),
+            }),
+            chain: source_chain.clone(),
+            nonce: None,
+        });
+        for op in request_data_json.op.iter() {
+            match op {
+                Operation::Swap(swap_op) => {
+                    uninitialized_task.steps.push(Step {
+                        meta: StepMeta::Swap(SwapStep {
+                            spend_asset: swap_op.data.spend_asset.as_bytes().into(),
+                            receive_asset: swap_op.data.receive_asset.as_bytes().into(),
+                            chain: swap_op.data.chain.clone(),
+                            dex: swap_op.data.dex.clone(),
+                            cap: swap_op.data.cap,
+                            flow: swap_op.data.flow,
+                            impact: swap_op.data.impact,
+                            b0: swap_op.data.b0,
+                            b1: swap_op.data.b1,
+                            spend: swap_op.data.spend,
+                        }),
+                        chain: swap_op.data.chain.clone(),
+                        nonce: None,
+                    });
+                }
+                Operation::Bridge(bridge_op) => uninitialized_task.steps.push(Step {
+                    meta: StepMeta::Bridge(BridgeStep {
+                        from: bridge_op.data.from.as_bytes().into(),
+                        source_chain: bridge_op.data.source_chain.clone(),
+                        to: bridge_op.data.to.as_bytes().into(),
+                        dest_chain: bridge_op.data.dest_chain.clone(),
+                        fee: bridge_op.data.fee,
+                        cap: bridge_op.data.cap,
+                        flow: bridge_op.data.flow,
+                        b0: bridge_op.data.b0,
+                        b1: bridge_op.data.b1,
+                        amount: bridge_op.data.amount,
+                    }),
+                    chain: bridge_op.data.source_chain.clone(),
+                    nonce: None,
+                }),
+            }
+        }
+
+        Ok(uninitialized_task)
+    }
+}
+
+#[derive(Deserialize)]
+struct RequestData {
+    op: Vec<Operation>,
+}
+
+#[derive(Deserialize)]
+enum Operation {
+    Swap(SwapOperation),
+    Bridge(BridgeOperation),
+}
+
+#[derive(Deserialize)]
+struct SwapOperation {
+    op_type: String,
+    data: SwapOperationData,
+}
+
+#[derive(Deserialize)]
+struct SwapOperationData {
+    spend_asset: Address,
+    receive_asset: Address,
+    chain: String,
+    dex: String,
+    cap: u128,
+    flow: u128,
+    impact: u128,
+    b0: Option<u128>,
+    b1: Option<u128>,
+    spend: u128,
+}
+
+#[derive(Deserialize)]
+struct BridgeOperation {
+    op_type: String,
+    data: BridgeOperationData,
+}
+
+#[derive(Deserialize)]
+struct BridgeOperationData {
+    from: Address,
+    source_chain: String,
+    to: Address,
+    dest_chain: String,
+    fee: u128,
+    cap: u128,
+    flow: u128,
+    b0: Option<u128>,
+    b1: Option<u128>,
+    amount: u128,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dotenv::dotenv;
+    use hex_literal::hex;
+
+    #[test]
+    fn test_fetch_task_from_evm() {
+        dotenv().ok();
+
+        pink_extension_runtime::mock_ext::mock_all_ext();
+
+        let worker_address: H160 = hex!("f60dB2d02af3f650798b59CB6D453b78f2C1BC90").into();
+        let task = ActivedTaskFetcher {
+            chain: Chain {
+                id: 0,
+                name: String::from("Ethereum"),
+                chain_type: ChainType::Evm,
+                endpoint: String::from(
+                    "https://eth-goerli.g.alchemy.com/v2/lLqSMX_1unN9Xrdy_BB9LLZRgbrXwZv2",
+                ),
+            },
+            worker: AccountInfo {
+                account20: worker_address.into(),
+                account32: [0; 32],
+            },
+        }
+        .fetch_task()
+        .unwrap();
+        println!("Evm task: {:?}", &task);
+        assert_eq!(task.steps.len(), 3);
     }
 }

--- a/contracts/index_executor/src/task.rs
+++ b/contracts/index_executor/src/task.rs
@@ -13,6 +13,8 @@ use scale::{Decode, Encode};
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
 pub enum TaskStatus {
     /// Task initial confirmed by user on source chain.
+    Actived,
+    /// Task has been initialized, e.g. being applied nonce.
     Initialized,
     /// Task is being executing with step index.
     /// Transaction can be indentified by worker account nonce on specific chain
@@ -34,7 +36,7 @@ pub struct Task {
     // Task status
     pub status: TaskStatus,
     // Source chain name
-    pub source: Vec<u8>,
+    pub source: String,
     /// All steps to included in the task
     pub steps: Vec<Step>,
     /// Current step index that is executing
@@ -43,6 +45,21 @@ pub struct Task {
     pub sender: Vec<u8>,
     /// Recipient address on dest chain
     pub recipient: Vec<u8>,
+}
+
+impl Default for Task {
+    fn default() -> Self {
+        Self {
+            id: [0; 32],
+            worker: [0; 32],
+            status: TaskStatus::Actived,
+            source: String::default(),
+            steps: vec![],
+            execute_index: 0,
+            sender: vec![],
+            recipient: vec![],
+        }
+    }
 }
 
 impl Task {


### PR DESCRIPTION
This PR implemented `ActivedTaskFetcher` that fetch task (user request with solution returned from off-chain solver) from [handler contract](https://github.com/Phala-Network/index-solidity/blob/main/contracts/Handler.sol) deployed on EVM chains.

The work flow would be:
- 1, user call [deposit](https://github.com/Phala-Network/index-solidity/blob/7b4458f9b8277df8a1c705a4d0f264476f42fcf2/contracts/Handler.sol#L65) method defined in `Handler` on EVM chain, with `solutioin` being converted to a JSON string we call it `request`. JSON format should look like this:
```sh
[{
        'op_type': 'swap',
        'source_chain': 'Ethereum',
        'dest_chain': 'Ethereum',
        'spend_asset': PHA_ON_GOERLI,
        'receive_asset': USDC_ON_GOERLI,
        'dex': 'UniswapV2',
        'fee': "0",
        'cap': "0",
        'flow': "0",
        'impact': "0",
        // Spend 100 PHA to swap USDC
        'spend': '100000000000000000000'
    }, {
        'op_type': 'bridge',
        'source_chain': 'Ethereum',
        'dest_chain': 'Moonbeam',
        'spend_asset': USDC_ON_GOERLI,
        'receive_asset': USDC_ON_MOONBEAM,
        'dex': '',
        'fee': "0",
        'cap': "0",
        'flow': "0",
        'impact': "0",
        // USDC has decimas 6, and assume PHA price is 0.12 USDC
        'spend': '12000000'
}]
```
It can be decoded by `pink-json` because we defined the pair rust object [OperationJson](https://github.com/Phala-Network/index-contract/blob/0aafa660e21a2968f64200bcae539b6954cb9aae/contracts/index_executor/src/claimer.rs#L256).

- 2, `ActivedTaskFetcher` fetch task through RPC method [getLastActivedRequest](https://github.com/Phala-Network/index-solidity/blob/7b4458f9b8277df8a1c705a4d0f264476f42fcf2/contracts/Handler.sol#L147) and [getRequestData](https://github.com/Phala-Network/index-solidity/blob/7b4458f9b8277df8a1c705a4d0f264476f42fcf2/contracts/Handler.sol#L165) defined in handler contract.
The later one will return the deposit data, to make `pink-web3` can decoded the deposit data corectly, we implemented trait `Detokenize` for struct [DepositData](https://github.com/Phala-Network/index-contract/blob/0aafa660e21a2968f64200bcae539b6954cb9aae/contracts/index_executor/src/claimer.rs#L133).

- 3, After we decoded the JSON from request string, we got all the solutions, then we convert it to a `Task` through function [to_task](https://github.com/Phala-Network/index-contract/blob/0aafa660e21a2968f64200bcae539b6954cb9aae/contracts/index_executor/src/claimer.rs#L186)

After all of this done, we got a uninitialized task that ready to be uploaded to rollup storage.