### PR TITLE
Implement Moonbeam to Phala executor

### DIFF
--- a/index/Cargo.lock
+++ b/index/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
  "gimli",
 ]
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -67,15 +67,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "array-init"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb6d71005dc22a708c7496eee5c8dc0300ee47355de6256c3b35b12b5fef596"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
 
 [[package]]
 name = "arrayref"
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "677d1d8ab452a3936018a687b20e6f7cf5363d713b732b8884001317b0e48aa3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -126,9 +126,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
  "addr2line",
  "cc",
@@ -171,11 +171,11 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.10.4"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9cf849ee05b2ee5fba5e36f97ff8ec2533916700fc0758d40d92136a42f3388"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -253,15 +253,15 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "cc"
-version = "1.0.74"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cfg-if"
@@ -271,9 +271,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "num-integer",
@@ -382,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.80"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7d4e43b25d3c994662706a1d4fcfc32aaa6afd287502c111b237093bb23f3a"
+checksum = "5add3fc1717409d029b20c5b6903fc0c0b02fa6741d820054f4a2efa5e5816fd"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -394,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.80"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f8829ddc213e2c1368e51a2564c552b65a8cb6a28f31e576270ac81d5e5827"
+checksum = "b4c87959ba14bc6fbc61df77c3fcfe180fc32b93538c4f1031dd802ccb5f2ff0"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -409,15 +409,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.80"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72537424b474af1460806647c41d4b6d35d09ef7fe031c5c2fa5766047cc56a"
+checksum = "69a3e162fde4e594ed2b07d0f83c6c67b745e7f28ce58c6df5e6b6bef99dfb59"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.80"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
+checksum = "3e7e2adeb6a0d4a282e581096b06e1791532b7d576dcde5ccd9382acf55db8e6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -468,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
@@ -564,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "environmental"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
+checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 
 [[package]]
 name = "ethbloom"
@@ -769,9 +769,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.26.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
 
 [[package]]
 name = "h2"
@@ -824,9 +824,9 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -1077,7 +1077,7 @@ dependencies = [
  "derive_more",
  "parity-scale-codec",
  "rand 0.8.5",
- "secp256k1 0.24.1",
+ "secp256k1 0.24.2",
  "sha2 0.10.6",
  "sha3",
 ]
@@ -1103,7 +1103,7 @@ dependencies = [
  "rand 0.8.5",
  "rlibc",
  "scale-info",
- "secp256k1 0.24.1",
+ "secp256k1 0.24.2",
  "sha2 0.10.6",
  "sha3",
  "static_assertions",
@@ -1262,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
@@ -1277,9 +1277,12 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1289,9 +1292,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libsecp256k1"
@@ -1343,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
@@ -1430,9 +1433,9 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.4"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
@@ -1474,9 +1477,9 @@ dependencies = [
 
 [[package]]
 name = "num-format"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b862ff8df690cf089058c98b183676a7ed0f974cc08b426800093227cbff3b"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
  "arrayvec 0.7.2",
  "itoa",
@@ -1515,9 +1518,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -1525,18 +1528,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.29.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+checksum = "8d864c91689fdc196779b98dba0aceac6118594c2df6ee5d943eb6a8df4d107a"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "opaque-debug"
@@ -1621,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1634,9 +1637,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "pbkdf2"
@@ -1841,8 +1844,8 @@ dependencies = [
 
 [[package]]
 name = "pink-web3"
-version = "0.19.3"
-source = "git+https://github.com/Phala-Network/pink-web3.git?branch=pink#c018c04bab07383e3ffab15729ba7af400803ea7"
+version = "0.19.4"
+source = "git+https://github.com/Phala-Network/pink-web3.git?branch=pink#1e4ed3018a319dea34a127aad13de5a36ad143d7"
 dependencies = [
  "arrayvec 0.7.2",
  "derive_more",
@@ -1862,9 +1865,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "primitive-types"
@@ -1893,18 +1896,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -2007,18 +2010,18 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a733f1746c929b4913fe48f8697fcf9c55e3304ba251a79ffb41adfeaf49c2"
+checksum = "8c78fb8c9293bcd48ef6fce7b4ca950ceaf21210de6e105a883ee280c0f7b9ed"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5887de4a01acafd221861463be6113e6e87275e79804e56779f4cdc131c60368"
+checksum = "9f9c0c92af03644e4806106281fe2e068ac5bc0ae74a707266d06ea27bccee5f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2027,9 +2030,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2047,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "reqwest"
@@ -2181,15 +2184,15 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "scale-info"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d8a765117b237ef233705cc2cc4c6a27fccd46eea6ef0c8c6dae5f3ef407f8"
+checksum = "001cf62ece89779fd16105b5f515ad0e5cedcd5440d3dd806bb067978e7c3608"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -2201,9 +2204,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcd47b380d8c4541044e341dcd9475f55ba37ddc50c908d945fc036a8642496"
+checksum = "303959cf613a6f6efd19ed4b4ad5bf79966a13352716299ad532cfb115f4205c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2237,9 +2240,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "sct"
@@ -2262,9 +2265,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff55dc09d460954e9ef2fa8a7ced735a964be9981fd50e870b2b3b0705e14964"
+checksum = "d9512ffd81e3a3503ed401f79c33168b9148c75038956039166cd750eaa037c3"
 dependencies = [
  "secp256k1-sys 0.6.1",
 ]
@@ -2298,24 +2301,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2324,9 +2327,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
@@ -2378,7 +2381,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -2387,7 +2390,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
  "keccak",
 ]
 
@@ -2535,7 +2538,7 @@ dependencies = [
  "regex",
  "scale-info",
  "schnorrkel",
- "secp256k1 0.24.1",
+ "secp256k1 0.24.2",
  "secrecy",
  "serde",
  "sp-core-hashing 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.29)",
@@ -2573,7 +2576,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "blake2",
  "byteorder",
- "digest 0.10.5",
+ "digest 0.10.6",
  "sha2 0.10.6",
  "sha3",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.29)",
@@ -2588,7 +2591,7 @@ checksum = "cbc2d1947252b7a4e403b0a260f596920443742791765ec111daa2bbf98eff25"
 dependencies = [
  "blake2",
  "byteorder",
- "digest 0.10.5",
+ "digest 0.10.6",
  "sha2 0.10.6",
  "sha3",
  "sp-std 6.0.0",
@@ -2651,7 +2654,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot",
- "secp256k1 0.24.1",
+ "secp256k1 0.24.2",
  "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.29)",
  "sp-externalities 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.29)",
  "sp-keystore",
@@ -2921,9 +2924,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "ss58-registry"
-version = "1.33.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab7554f8a8b6f8d71cd5a8e6536ef116e2ce0504cf97ebf16311d58065dc8a6"
+checksum = "23d92659e7d18d82b803824a9ba5a6022cff101c3491d027c1c1d8d30e749284"
 dependencies = [
  "Inflector",
  "num-format",
@@ -2961,9 +2964,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2999,18 +3002,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3125,9 +3128,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]
@@ -3249,22 +3252,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "digest 0.10.5",
+ "digest 0.10.6",
  "rand 0.8.5",
  "static_assertions",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "uint"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45526d29728d135c2900b0d30573fe3ee79fceb12ef534c7bb30e810a91b601"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -3280,9 +3283,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-normalization"
@@ -3580,9 +3583,9 @@ dependencies = [
 
 [[package]]
 name = "wyz"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
@@ -3623,9 +3626,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/index/src/abis/xtokens-abi.json
+++ b/index/src/abis/xtokens-abi.json
@@ -1,0 +1,312 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "currencyAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint8",
+            "name": "parents",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes[]",
+            "name": "interior",
+            "type": "bytes[]"
+          }
+        ],
+        "internalType": "struct Xtokens.Multilocation",
+        "name": "destination",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint64",
+        "name": "weight",
+        "type": "uint64"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "uint8",
+                "name": "parents",
+                "type": "uint8"
+              },
+              {
+                "internalType": "bytes[]",
+                "name": "interior",
+                "type": "bytes[]"
+              }
+            ],
+            "internalType": "struct Xtokens.Multilocation",
+            "name": "location",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct Xtokens.MultiAsset[]",
+        "name": "assets",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint32",
+        "name": "feeItem",
+        "type": "uint32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint8",
+            "name": "parents",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes[]",
+            "name": "interior",
+            "type": "bytes[]"
+          }
+        ],
+        "internalType": "struct Xtokens.Multilocation",
+        "name": "destination",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint64",
+        "name": "weight",
+        "type": "uint64"
+      }
+    ],
+    "name": "transferMultiAssets",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "currencyAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct Xtokens.Currency[]",
+        "name": "currencies",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint32",
+        "name": "feeItem",
+        "type": "uint32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint8",
+            "name": "parents",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes[]",
+            "name": "interior",
+            "type": "bytes[]"
+          }
+        ],
+        "internalType": "struct Xtokens.Multilocation",
+        "name": "destination",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint64",
+        "name": "weight",
+        "type": "uint64"
+      }
+    ],
+    "name": "transferMultiCurrencies",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint8",
+            "name": "parents",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes[]",
+            "name": "interior",
+            "type": "bytes[]"
+          }
+        ],
+        "internalType": "struct Xtokens.Multilocation",
+        "name": "asset",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint8",
+            "name": "parents",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes[]",
+            "name": "interior",
+            "type": "bytes[]"
+          }
+        ],
+        "internalType": "struct Xtokens.Multilocation",
+        "name": "destination",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint64",
+        "name": "weight",
+        "type": "uint64"
+      }
+    ],
+    "name": "transferMultiasset",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint8",
+            "name": "parents",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes[]",
+            "name": "interior",
+            "type": "bytes[]"
+          }
+        ],
+        "internalType": "struct Xtokens.Multilocation",
+        "name": "asset",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "fee",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint8",
+            "name": "parents",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes[]",
+            "name": "interior",
+            "type": "bytes[]"
+          }
+        ],
+        "internalType": "struct Xtokens.Multilocation",
+        "name": "destination",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint64",
+        "name": "weight",
+        "type": "uint64"
+      }
+    ],
+    "name": "transferMultiassetWithFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "currencyAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "fee",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint8",
+            "name": "parents",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes[]",
+            "name": "interior",
+            "type": "bytes[]"
+          }
+        ],
+        "internalType": "struct Xtokens.Multilocation",
+        "name": "destination",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint64",
+        "name": "weight",
+        "type": "uint64"
+      }
+    ],
+    "name": "transferWithFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/index/src/executors/bridge_executors/mod.rs
+++ b/index/src/executors/bridge_executors/mod.rs
@@ -35,7 +35,7 @@ impl ChainBridgeEvm2Phala {
             contract: Contract::from_json(
                 eth,
                 bridge_address,
-                include_bytes!("../abis/chainbridge-abi.json"),
+                include_bytes!("../../abis/chainbridge-abi.json"),
             )
             .expect("Bad abi data"),
         };

--- a/index/src/executors/bridge_executors/mod.rs
+++ b/index/src/executors/bridge_executors/mod.rs
@@ -20,6 +20,8 @@ use scale::Encode;
 use subrpc::{create_transaction, send_transaction};
 use xcm::v1::{prelude::*, AssetId, Fungibility, Junction, Junctions, MultiAsset, MultiLocation};
 
+mod moonbeam_to_phala;
+
 #[derive(Clone)]
 pub struct ChainBridgeEvm2Phala {
     // (asset_contract_address, resource_id)

--- a/index/src/executors/bridge_executors/moonbeam_to_phala.rs
+++ b/index/src/executors/bridge_executors/moonbeam_to_phala.rs
@@ -1,6 +1,7 @@
 use crate::prelude::BridgeExecutor;
 use crate::prelude::Error;
 use crate::transactors::XtokenClient;
+use alloc::vec::Vec;
 use pink_web3::ethabi::Address;
 
 use pink_web3::{
@@ -57,6 +58,7 @@ impl BridgeExecutor for Moonbeam2PhalaExecutor {
                 recipient,
             )
             .unwrap();
+        // dbg!(tx_id);
         Ok(())
     }
 }

--- a/index/src/executors/bridge_executors/moonbeam_to_phala.rs
+++ b/index/src/executors/bridge_executors/moonbeam_to_phala.rs
@@ -85,13 +85,13 @@ mod tests {
         let recipient =
             hex::decode("da1ada496c0e6e3c122aa17f51ccd7254782effab31b24575d54e0350e7f2f6a")
                 .unwrap();
-        _ = exec
-            .transfer(
-                signer,
-                hex::decode("ffffffff63d24ecc8eb8a7b5d0803e900f7b6ced").unwrap(),
-                recipient,
-                1_000_000_000_000,
-            )
-            .unwrap();
+        exec.transfer(
+            signer,
+            hex::decode("ffffffff63d24ecc8eb8a7b5d0803e900f7b6ced").unwrap(),
+            recipient,
+            1_000_000_000_000,
+        )
+        .unwrap();
+        // test txn: https://moonbeam.moonscan.io/tx/0x47a5fdea2e3bb807296b7d7c5e708b4db5a0aca732ef37ee0e173df3d3942872
     }
 }

--- a/index/src/executors/bridge_executors/moonbeam_to_phala.rs
+++ b/index/src/executors/bridge_executors/moonbeam_to_phala.rs
@@ -18,7 +18,7 @@ pub struct Moonbeam2PhalaExecutor {
 
 impl Moonbeam2PhalaExecutor {
     #[allow(dead_code)]
-    pub fn new(rpc: &str, bridge_address: Address) -> Self {
+    pub fn new(rpc: &str, xtoken_address: Address) -> Self {
         let eth = Eth::new(PinkHttp::new(rpc));
         let bridge_contract = XtokenClient {
             contract: Contract::from_json(

--- a/index/src/executors/bridge_executors/moonbeam_to_phala.rs
+++ b/index/src/executors/bridge_executors/moonbeam_to_phala.rs
@@ -71,6 +71,7 @@ mod tests {
     use primitive_types::H160;
 
     #[test]
+    #[ignore = "to prevent the private keys being leaked, run this test with `SECRET_KEY=<your-private-key> cargo test moonbeam_xtokens -- --nocapture`"]
     fn moonbeam_xtokens() {
         pink_extension_runtime::mock_ext::mock_all_ext();
 

--- a/index/src/executors/bridge_executors/moonbeam_to_phala.rs
+++ b/index/src/executors/bridge_executors/moonbeam_to_phala.rs
@@ -23,7 +23,7 @@ impl Moonbeam2PhalaExecutor {
         let bridge_contract = XtokenClient {
             contract: Contract::from_json(
                 eth,
-                bridge_address,
+                xtoken_address,
                 include_bytes!("../../abis/xtokens-abi.json"),
             )
             .expect("Bad abi data"),

--- a/index/src/executors/bridge_executors/moonbeam_to_phala.rs
+++ b/index/src/executors/bridge_executors/moonbeam_to_phala.rs
@@ -1,0 +1,187 @@
+// use dyn_clone::DynClone;
+
+use crate::{prelude::Error, transactors::ChainBridgeClient, utils::ToArray};
+use pink_web3::contract::tokens::{Tokenizable, Tokenize};
+use pink_web3::contract::Options;
+use pink_web3::ethabi::{Address, Bytes, Token};
+use pink_web3::signing::Key;
+use pink_web3::transports::resolve_ready;
+use pink_web3::{
+    api::{Eth, Namespace},
+    contract::Contract,
+    keys::pink::KeyPair,
+    transports::PinkHttp,
+};
+use primitive_types::{H160, H256, U256};
+use scale::Encode;
+use xcm::v0::NetworkId;
+use xcm::v1::{Junction, Junctions, MultiLocation};
+use xcm::v2::{Weight, WeightLimit};
+
+pub trait BridgeExecutor /* : DynClone */ {
+    fn transfer(
+        &self,
+        signer: [u8; 32],
+        recipient: Vec<u8>,
+        amount: u128,
+    ) -> core::result::Result<H256, Error>;
+}
+
+pub struct XtokenClient {
+    pub contract: Contract<PinkHttp>,
+}
+
+impl XtokenClient {
+    pub fn transfer(
+        &self,
+        signer: KeyPair,
+        token_address: Address,
+        amount: u128,
+        parents: u8,
+        parachain: u32,
+        network: u8,
+        recipient: [u8; 32],
+    ) -> core::result::Result<H256, Error> {
+        let weight: u64 = 6000000000;
+        let location = Token::Tuple(vec![
+            Token::Uint(parents.into()),
+            Token::Array(vec![
+                Token::Bytes(
+                    // Parachain(#[codec(compact)] u32),
+                    {
+                        let mut bytes: Vec<u8> = vec![];
+                        let mut enum_id = (0 as u8).to_be_bytes().to_vec();
+                        let mut chain_id = parachain.to_be_bytes().to_vec();
+                        bytes.append(&mut enum_id);
+                        bytes.append(&mut chain_id);
+                        bytes
+                    },
+                ),
+                Token::Bytes(
+                    // AccountId32 { network: NetworkId, id: [u8; 32] },
+                    {
+                        let mut bytes: Vec<u8> = vec![];
+                        let mut enum_id = (1 as u8).to_be_bytes().to_vec();
+                        let mut recipient_vec = recipient.to_vec();
+                        let mut network_vec = network.to_be_bytes().to_vec();
+                        bytes.append(&mut enum_id);
+                        bytes.append(&mut recipient_vec);
+                        bytes.append(&mut network_vec);
+                        bytes
+                    },
+                ),
+            ]),
+        ]);
+        let amount: U256 = amount.into();
+        let params = (token_address, amount, location, weight);
+
+        dbg!(signer.address());
+        // Estiamte gas before submission
+        let gas = resolve_ready(self.contract.estimate_gas(
+            "transfer",
+            params.clone(),
+            signer.address(),
+            Options::default(),
+        ))
+        .expect("FIXME: failed to estiamte gas");
+
+        dbg!(&gas);
+
+        // Actually submit the tx (no guarantee for success)
+        let tx_id = resolve_ready(self.contract.signed_call(
+            "transfer",
+            params,
+            Options::with(|opt| opt.gas = Some(gas)),
+            signer,
+        ))
+        .expect("FIXME: submit failed");
+        Ok(tx_id)
+    }
+}
+
+pub struct Moonbeam2PhalaExecutor {
+    // (asset_contract_address, resource_id)
+    //assets: (Address, [u8; 32]),
+    asset_contract_address: Address,
+    bridge_contract: XtokenClient,
+}
+
+impl Moonbeam2PhalaExecutor {
+    pub fn new(rpc: &str, bridge_address: Address, asset_contract_address: Address) -> Self {
+        let eth = Eth::new(PinkHttp::new(rpc));
+        let bridge_contract = XtokenClient {
+            contract: Contract::from_json(
+                eth,
+                bridge_address,
+                include_bytes!("../../abis/xtokens-abi.json"),
+            )
+            .expect("Bad abi data"),
+        };
+
+        Self {
+            asset_contract_address,
+            bridge_contract,
+        }
+    }
+}
+
+impl BridgeExecutor for Moonbeam2PhalaExecutor {
+    fn transfer(
+        &self,
+        signer: [u8; 32],
+        recipient: Vec<u8>,
+        amount: u128,
+    ) -> core::result::Result<H256, Error> {
+        let signer = KeyPair::from(signer);
+        let recipient_32: [u8; 32] = recipient.to_array();
+        let interior = Junctions::X2(
+            Junction::Parachain(2035),
+            Junction::AccountId32 {
+                network: NetworkId::Any,
+                id: recipient_32,
+            },
+        );
+        dbg!(hex::encode(Junction::Parachain(2035).encode()));
+        let tx_id = self
+            .bridge_contract
+            .transfer(
+                signer,
+                self.asset_contract_address.clone(),
+                amount,
+                1,
+                2035,
+                0,
+                recipient_32,
+            )
+            .unwrap();
+        Ok(tx_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::str::FromStr;
+
+    use super::*;
+    use primitive_types::H160;
+
+    #[test]
+    fn moonbeam_xtokens() {
+        pink_extension_runtime::mock_ext::mock_all_ext();
+
+        let exec = Moonbeam2PhalaExecutor::new(
+            "https://moonbeam.public.blastapi.io",
+            H160::from_str("0x0000000000000000000000000000000000000804").unwrap(),
+            H160::from_str("0xffffffff63d24ecc8eb8a7b5d0803e900f7b6ced").unwrap(),
+        );
+        let secret_key = std::env::vars().find(|x| x.0 == "SECRET_KEY");
+        let secret_key = secret_key.unwrap().1;
+        let secret_bytes = hex::decode(secret_key).unwrap();
+        let signer: [u8; 32] = secret_bytes.to_array();
+        let recipient =
+            hex::decode("da1ada496c0e6e3c122aa17f51ccd7254782effab31b24575d54e0350e7f2f6a")
+                .unwrap();
+        let tx_id = exec.transfer(signer, recipient, 1_000_000_000_000).unwrap();
+        dbg!(tx_id);
+    }
+}

--- a/index/src/executors/mod.rs
+++ b/index/src/executors/mod.rs
@@ -1,4 +1,4 @@
-pub mod bridge_executor;
+pub mod bridge_executors;
 pub mod dex_executor;
 
 #[cfg(test)]

--- a/index/src/prelude.rs
+++ b/index/src/prelude.rs
@@ -1,4 +1,4 @@
-pub use super::executors::bridge_executor::{ChainBridgeEvm2Phala, ChainBridgePhala2Evm};
+pub use super::executors::bridge_executors::{ChainBridgeEvm2Phala, ChainBridgePhala2Evm};
 pub use super::executors::dex_executor::UniswapV2Executor;
 pub use crate::traits::common::Error;
 pub use crate::traits::executor::{BridgeExecutor, DexExecutor};

--- a/index/src/traits/common.rs
+++ b/index/src/traits/common.rs
@@ -17,6 +17,8 @@ pub enum Error {
     InvalidBody,
     InvalidSignature,
     Ss58,
+    FailedToGetGas,
+    FailedToSubmitTransaction,
 }
 
 #[derive(Clone, Encode, Decode, Eq, PartialEq, Debug)]

--- a/index/src/transactors/mod.rs
+++ b/index/src/transactors/mod.rs
@@ -1,2 +1,4 @@
 mod evm_transactor;
 pub use evm_transactor::ChainBridgeClient;
+mod xtokens;
+pub use xtokens::XtokenClient;

--- a/index/src/transactors/xtokens.rs
+++ b/index/src/transactors/xtokens.rs
@@ -12,6 +12,7 @@ pub struct XtokenClient {
 }
 
 impl XtokenClient {
+    #![allow(clippy::too_many_arguments)]
     pub fn transfer(
         &self,
         signer: KeyPair,
@@ -30,7 +31,7 @@ impl XtokenClient {
                     // Parachain(#[codec(compact)] u32),
                     {
                         let mut bytes: Vec<u8> = vec![];
-                        let mut enum_id = (0 as u8).to_be_bytes().to_vec();
+                        let mut enum_id = 0_u8.to_be_bytes().to_vec();
                         let mut chain_id = parachain.to_be_bytes().to_vec();
                         bytes.append(&mut enum_id);
                         bytes.append(&mut chain_id);
@@ -41,7 +42,7 @@ impl XtokenClient {
                     // AccountId32 { network: NetworkId, id: [u8; 32] },
                     {
                         let mut bytes: Vec<u8> = vec![];
-                        let mut enum_id = (1 as u8).to_be_bytes().to_vec();
+                        let mut enum_id = 1_u8.to_be_bytes().to_vec();
                         let mut network_vec = network.to_be_bytes().to_vec();
                         let mut recipient = recipient;
                         bytes.append(&mut enum_id);

--- a/index/src/transactors/xtokens.rs
+++ b/index/src/transactors/xtokens.rs
@@ -1,4 +1,6 @@
 use crate::prelude::Error;
+use alloc::vec;
+use alloc::vec::Vec;
 use pink_web3::contract::Options;
 use pink_web3::ethabi::{Address, Token};
 use pink_web3::signing::Key;
@@ -65,8 +67,6 @@ impl XtokenClient {
         ))
         .expect("FIXME: failed to estiamte gas");
 
-        dbg!(&gas);
-
         // Actually submit the tx (no guarantee for success)
         let tx_id = resolve_ready(self.contract.signed_call(
             "transfer",
@@ -75,7 +75,7 @@ impl XtokenClient {
             signer,
         ))
         .expect("FIXME: submit failed");
-        dbg!(tx_id);
+
         Ok(tx_id)
     }
 }

--- a/index/src/transactors/xtokens.rs
+++ b/index/src/transactors/xtokens.rs
@@ -20,7 +20,7 @@ impl XtokenClient {
         parents: u8,
         parachain: u32,
         network: u8,
-        recipient: [u8; 32],
+        recipient: Vec<u8>,
     ) -> core::result::Result<H256, Error> {
         let weight: u64 = 6000000000;
         let location = Token::Tuple(vec![
@@ -42,10 +42,10 @@ impl XtokenClient {
                     {
                         let mut bytes: Vec<u8> = vec![];
                         let mut enum_id = (1 as u8).to_be_bytes().to_vec();
-                        let mut recipient_vec = recipient.to_vec();
                         let mut network_vec = network.to_be_bytes().to_vec();
+                        let mut recipient = recipient;
                         bytes.append(&mut enum_id);
-                        bytes.append(&mut recipient_vec);
+                        bytes.append(&mut recipient);
                         bytes.append(&mut network_vec);
                         bytes
                     },
@@ -55,7 +55,6 @@ impl XtokenClient {
         let amount: U256 = amount.into();
         let params = (token_address, amount, location, weight);
 
-        dbg!(signer.address());
         // Estiamte gas before submission
         let gas = resolve_ready(self.contract.estimate_gas(
             "transfer",
@@ -75,6 +74,7 @@ impl XtokenClient {
             signer,
         ))
         .expect("FIXME: submit failed");
+        dbg!(tx_id);
         Ok(tx_id)
     }
 }

--- a/index/src/transactors/xtokens.rs
+++ b/index/src/transactors/xtokens.rs
@@ -1,0 +1,80 @@
+use crate::prelude::Error;
+use pink_web3::contract::Options;
+use pink_web3::ethabi::{Address, Token};
+use pink_web3::signing::Key;
+use pink_web3::transports::resolve_ready;
+use pink_web3::{contract::Contract, keys::pink::KeyPair, transports::PinkHttp};
+use primitive_types::{H256, U256};
+
+#[derive(Clone)]
+pub struct XtokenClient {
+    pub contract: Contract<PinkHttp>,
+}
+
+impl XtokenClient {
+    pub fn transfer(
+        &self,
+        signer: KeyPair,
+        token_address: Address,
+        amount: u128,
+        parents: u8,
+        parachain: u32,
+        network: u8,
+        recipient: [u8; 32],
+    ) -> core::result::Result<H256, Error> {
+        let weight: u64 = 6000000000;
+        let location = Token::Tuple(vec![
+            Token::Uint(parents.into()),
+            Token::Array(vec![
+                Token::Bytes(
+                    // Parachain(#[codec(compact)] u32),
+                    {
+                        let mut bytes: Vec<u8> = vec![];
+                        let mut enum_id = (0 as u8).to_be_bytes().to_vec();
+                        let mut chain_id = parachain.to_be_bytes().to_vec();
+                        bytes.append(&mut enum_id);
+                        bytes.append(&mut chain_id);
+                        bytes
+                    },
+                ),
+                Token::Bytes(
+                    // AccountId32 { network: NetworkId, id: [u8; 32] },
+                    {
+                        let mut bytes: Vec<u8> = vec![];
+                        let mut enum_id = (1 as u8).to_be_bytes().to_vec();
+                        let mut recipient_vec = recipient.to_vec();
+                        let mut network_vec = network.to_be_bytes().to_vec();
+                        bytes.append(&mut enum_id);
+                        bytes.append(&mut recipient_vec);
+                        bytes.append(&mut network_vec);
+                        bytes
+                    },
+                ),
+            ]),
+        ]);
+        let amount: U256 = amount.into();
+        let params = (token_address, amount, location, weight);
+
+        dbg!(signer.address());
+        // Estiamte gas before submission
+        let gas = resolve_ready(self.contract.estimate_gas(
+            "transfer",
+            params.clone(),
+            signer.address(),
+            Options::default(),
+        ))
+        .expect("FIXME: failed to estiamte gas");
+
+        dbg!(&gas);
+
+        // Actually submit the tx (no guarantee for success)
+        let tx_id = resolve_ready(self.contract.signed_call(
+            "transfer",
+            params,
+            Options::with(|opt| opt.gas = Some(gas)),
+            signer,
+        ))
+        .expect("FIXME: submit failed");
+        Ok(tx_id)
+    }
+}

--- a/index/src/transactors/xtokens.rs
+++ b/index/src/transactors/xtokens.rs
@@ -65,7 +65,7 @@ impl XtokenClient {
             signer.address(),
             Options::default(),
         ))
-        .expect("FIXME: failed to estiamte gas");
+        .map_err(|_| Error::FailedToGetGas)?;
 
         // Actually submit the tx (no guarantee for success)
         let tx_id = resolve_ready(self.contract.signed_call(
@@ -74,7 +74,7 @@ impl XtokenClient {
             Options::with(|opt| opt.gas = Some(gas)),
             signer,
         ))
-        .expect("FIXME: submit failed");
+        .map_err(|_| Error::FailedToSubmitTransaction)?;
 
         Ok(tx_id)
     }


### PR DESCRIPTION
This PR corresponds to the issue https://github.com/Phala-Network/index-contract/issues/26.

One thing that might need improvement is the `XTokensClient`, currently it just hardcodes some values, for example, the enum id of `Junction` types and the composition of the `Multilocation`. When more uses case come up, we will make `XTokensClient` more general, for now it just works for this use case.
