### PR TITLE
Claim task from pallet-index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2229,9 +2229,9 @@ checksum = "3da595e670ee22ac5ae563a55388ce2148d68b993fe09ca0099a247cb55cf790"
 
 [[package]]
 name = "pink-subrpc"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4d515824efb66f1d5433368501c2d7e617131f387d244c7274070811d9e1cd"
+checksum = "ada84ef47e0fd6b10e0fdee583ed731161a578ee8e2a59e8431802a3fd86b559"
 dependencies = [
  "base58",
  "hex",

--- a/contracts/index_executor/Cargo.toml
+++ b/contracts/index_executor/Cargo.toml
@@ -27,7 +27,7 @@ pink-kv-session = { version = "0.2.0", default-features = false }
 pink-extension = { version = "0.4.1", default-features = false }
 pink-web3 = { version = "0.20.1", git = "https://github.com/Phala-Network/pink-web3.git", branch = "pink", default-features = false, features = ["pink"]}
 pink-json = { git = "https://github.com/Phala-Network/pink-json.git", branch = "pink", default-features = false, features = ["custom-error-messages"] }
-pink-subrpc = { version = "0.4.1", default-features = false }
+pink-subrpc = { version = "0.4.2", default-features = false }
 index = { path = "../../index", default-features = false }
 
 [dev-dependencies]

--- a/contracts/index_executor/src/claimer.rs
+++ b/contracts/index_executor/src/claimer.rs
@@ -9,7 +9,12 @@ use super::step::{Step, StepMeta};
 use super::swap::SwapStep;
 use super::task::{OnchainTasks, Task, TaskId};
 use super::traits::Runner;
+use xcm::latest::AssetId as XcmAssetId;
 
+use pink_subrpc::{
+    get_storage,
+    storage::{storage_map_blake2_128_prefix, storage_prefix},
+};
 use pink_web3::{
     api::{Eth, Namespace},
     contract::{tokens::Detokenize, Contract, Error as PinkError, Options},
@@ -165,7 +170,7 @@ impl ActivedTaskFetcher {
     pub fn fetch_task(&self) -> Result<Option<Task>, &'static str> {
         match self.chain.chain_type {
             ChainType::Evm => Ok(self.query_evm_actived_request(&self.chain, &self.worker)?),
-            ChainType::Sub => Err("Unimplemented"),
+            ChainType::Sub => Ok(self.query_sub_actived_request(&self.chain, &self.worker)?),
         }
     }
 
@@ -205,7 +210,7 @@ impl ActivedTaskFetcher {
             "getLastActivedRequest, return request_id: {:?}",
             hex::encode(request_id)
         );
-        let deposit_data: DepositData = resolve_ready(handler.query(
+        let evm_deposit_data: EvmDepositData = resolve_ready(handler.query(
             "getRequestData",
             request_id,
             None,
@@ -217,27 +222,81 @@ impl ActivedTaskFetcher {
             "Fetch deposit data successfully for request {:?} on {:?}, deposit data: {:?}",
             &hex::encode(request_id),
             &chain.name,
-            &deposit_data,
+            &evm_deposit_data,
         );
+        let deposit_data: DepositData = evm_deposit_data.into();
         let task = deposit_data.to_task(&chain.name, request_id)?;
         Ok(Some(task))
     }
+
+    fn query_sub_actived_request(
+        &self,
+        chain: &Chain,
+        worker: &AccountInfo,
+    ) -> Result<Option<Task>, &'static str> {
+        if let Some(raw_storage) = get_storage(
+            &chain.endpoint,
+            &storage_map_blake2_128_prefix(
+                &storage_prefix("PalletIndex", "ActivedRequests")[..],
+                &worker.account32,
+            ),
+            None,
+        )
+        // .log_err("Read storage [actived request] failed")
+        .map_err(|_| "FailedGetRequestData")?
+        {
+            let actived_requests: Vec<[u8; 32]> =
+                scale::Decode::decode(&mut raw_storage.as_slice())
+                    // .log_err("Decode storage [sub native balance] failed")
+                    .map_err(|_| "DecodeStorageFailed")?;
+            if actived_requests.len() > 0 {
+                let oldest_request = actived_requests[0];
+                if let Some(raw_storage) = get_storage(
+                    &chain.endpoint,
+                    &storage_map_blake2_128_prefix(
+                        &storage_prefix("PalletIndex", "DepositRecords")[..],
+                        &oldest_request,
+                    ),
+                    None,
+                )
+                // .log_err("Read storage [actived request] failed")
+                .map_err(|_| "FailedGetRequestData")?
+                {
+                    let sub_deposit_data: SubDepositData =
+                        scale::Decode::decode(&mut raw_storage.as_slice())
+                            // .log_err("Decode storage [sub native balance] failed")
+                            .map_err(|_| "DecodeStorageFailed")?;
+                    pink_extension::debug!(
+                        "Fetch deposit data successfully for request {:?} on {:?}, deposit data: {:?}",
+                        &hex::encode(oldest_request),
+                        &chain.name,
+                        &sub_deposit_data,
+                    );
+                    let deposit_data: DepositData = sub_deposit_data.into();
+                    let task = deposit_data.to_task(&chain.name, oldest_request)?;
+                    Ok(Some(task))
+                } else {
+                    Err("DepositInfoNotFound")
+                }
+            } else {
+                Ok(None)
+            }
+        } else {
+            Ok(None)
+        }
+    }
 }
 
-// Define the structures to parse deposit data json
-#[allow(dead_code)]
 #[derive(Debug)]
-struct DepositData {
+struct EvmDepositData {
     // TODO: use Bytes
     sender: Address,
-    // TODO: user Bytes
-    token: Address,
     amount: U256,
     recipient: Vec<u8>,
     request: String,
 }
 
-impl Detokenize for DepositData {
+impl Detokenize for EvmDepositData {
     fn from_tokens(tokens: Vec<Token>) -> Result<Self, PinkError>
     where
         Self: Sized,
@@ -248,20 +307,17 @@ impl Detokenize for DepositData {
                 Token::Tuple(deposit_data) => {
                     match (
                         deposit_data[0].clone(),
-                        deposit_data[1].clone(),
                         deposit_data[2].clone(),
                         deposit_data[3].clone(),
                         deposit_data[4].clone(),
                     ) {
                         (
                             Token::Address(sender),
-                            Token::Address(token),
                             Token::Uint(amount),
                             Token::Bytes(recipient),
                             Token::String(request),
-                        ) => Ok(DepositData {
+                        ) => Ok(EvmDepositData {
                             sender,
-                            token,
                             amount,
                             recipient,
                             request,
@@ -277,6 +333,49 @@ impl Detokenize for DepositData {
             }
         } else {
             Err(PinkError::InvalidOutputType(String::from("Invalid length")))
+        }
+    }
+}
+
+// Copy from pallet-index
+#[derive(Clone, Decode, Encode, Eq, PartialEq, Ord, PartialOrd, Debug)]
+pub struct SubDepositData {
+    pub sender: [u8; 32],
+    pub asset: XcmAssetId,
+    pub amount: u128,
+    pub recipient: Vec<u8>,
+    pub request: Vec<u8>,
+}
+
+// Define the structures to parse deposit data json
+#[allow(dead_code)]
+#[derive(Debug)]
+struct DepositData {
+    // TODO: use Bytes
+    sender: Vec<u8>,
+    amount: u128,
+    recipient: Vec<u8>,
+    request: String,
+}
+
+impl From<EvmDepositData> for DepositData {
+    fn from(value: EvmDepositData) -> Self {
+        Self {
+            sender: value.sender.as_bytes().into(),
+            amount: value.amount.try_into().expect("Amount overflow"),
+            recipient: value.recipient,
+            request: value.request,
+        }
+    }
+}
+
+impl From<SubDepositData> for DepositData {
+    fn from(value: SubDepositData) -> Self {
+        Self {
+            sender: value.sender.into(),
+            amount: value.amount,
+            recipient: value.recipient,
+            request: String::from_utf8_lossy(&value.request).to_string(),
         }
     }
 }
@@ -298,7 +397,7 @@ impl DepositData {
         let mut uninitialized_task = Task {
             id,
             source: source_chain.into(),
-            sender: self.sender.as_bytes().into(),
+            sender: self.sender.clone(),
             recipient: self.recipient.clone(),
             ..Default::default()
         };

--- a/examples/semi_bridge/Cargo.toml
+++ b/examples/semi_bridge/Cargo.toml
@@ -20,7 +20,7 @@ hex = { version = "0.4.3", default-features = false }
 
 pink-extension = { version = "0.4.1", default-features = false, features = ["ink-as-dependency"] }
 pink-web3 = { git = "https://github.com/Phala-Network/pink-web3.git", branch = "pink", default-features = false, features = ["pink", "signing"]}
-pink-subrpc = { version = "0.4.1", default-features = false }
+pink-subrpc = { version = "0.4.2", default-features = false }
 
 index = { path = "../../index", default-features = false }
 

--- a/examples/system_remark/Cargo.toml
+++ b/examples/system_remark/Cargo.toml
@@ -20,14 +20,14 @@ hex = { version = "0.4.3", default-features = false }
 
 pink-extension = { version = "0.4.1", default-features = false, features = ["ink-as-dependency"] }
 pink-web3 = { git = "https://github.com/Phala-Network/pink-web3.git", branch = "pink", default-features = false, features = ["pink", "signing"]}
-pink-subrpc = { version = "0.4.1", default-features = false }
+pink-subrpc = { version = "0.4.2", default-features = false }
 
 index = { path = "../../index", default-features = false }
 
 [dev-dependencies]
 pink-extension-runtime = "0.4.0"
 dotenv = "0.15.0"
-pink-subrpc = { version = "0.4.0", default-features = false }
+pink-subrpc = { version = "0.4.2", default-features = false }
 
 [lib]
 name = "system_remark"

--- a/index/Cargo.lock
+++ b/index/Cargo.lock
@@ -1929,9 +1929,9 @@ dependencies = [
 
 [[package]]
 name = "pink-subrpc"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4d515824efb66f1d5433368501c2d7e617131f387d244c7274070811d9e1cd"
+checksum = "ada84ef47e0fd6b10e0fdee583ed731161a578ee8e2a59e8431802a3fd86b559"
 dependencies = [
  "base58",
  "hex",

--- a/index/Cargo.toml
+++ b/index/Cargo.toml
@@ -24,7 +24,7 @@ sp-core-hashing = { version = "4.0.0", git = "https://github.com/paritytech/subs
 sp-runtime = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.29", default-features = false }
 
 pink-json = { git = "https://github.com/Phala-Network/pink-json.git", branch = "pink", default-features = false }
-pink-subrpc = { version = "0.4.1", default-features = false }
+pink-subrpc = { version = "0.4.2", default-features = false }
 
 ss58-registry = { version = "1.33.0", default-features = false }
 base58 = { version = "0.2.0", default-features = false }

--- a/index/src/graph/chain.rs
+++ b/index/src/graph/chain.rs
@@ -6,7 +6,7 @@ use alloc::{vec, vec::Vec};
 use pink_extension::ResultExt;
 use pink_subrpc::{
     get_next_nonce, get_ss58addr_version, get_storage,
-    hasher::{Blake2_128, Twox64},
+    hasher::{Blake2_128Concat, Twox64Concat},
     storage::{storage_double_map_prefix, storage_map_prefix, storage_prefix},
     Ss58Codec,
 };
@@ -133,7 +133,7 @@ impl BalanceFetcher for Chain {
                 if self.is_native(&asset) {
                     if let Some(raw_storage) = get_storage(
                         &self.endpoint,
-                        &storage_map_prefix::<Blake2_128>(
+                        &storage_map_prefix::<Blake2_128Concat>(
                             &storage_prefix("System", "Account")[..],
                             &public_key,
                         ),
@@ -161,7 +161,7 @@ impl BalanceFetcher for Chain {
                                 .ok_or(Error::AssetNotRecognized)?;
                             if let Some(raw_storage) = get_storage(
                                 &self.endpoint,
-                                &storage_double_map_prefix::<Blake2_128, Blake2_128>(
+                                &storage_double_map_prefix::<Blake2_128Concat, Blake2_128Concat>(
                                     &storage_prefix("Assets", "Account")[..],
                                     &asset_id.to_le_bytes(),
                                     &public_key,
@@ -188,7 +188,7 @@ impl BalanceFetcher for Chain {
                                 .ok_or(Error::AssetNotRecognized)?;
                             if let Some(raw_storage) = get_storage(
                                 &self.endpoint,
-                                &storage_double_map_prefix::<Blake2_128, Twox64>(
+                                &storage_double_map_prefix::<Blake2_128Concat, Twox64Concat>(
                                     &storage_prefix("Tokens", "Accounts")[..],
                                     &public_key,
                                     &currency_id.encode(),

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -11,6 +11,7 @@
     "@phala/sdk": "^0.3.8-beta.0",
     "@polkadot/api": "^9.13.6",
     "@polkadot/api-contract": "^9.13.6",
+    "bn.js": "^5.2.1",
     "console-stamp": "^3.1.0"
   }
 }

--- a/scripts/src/sub-deposit.js
+++ b/scripts/src/sub-deposit.js
@@ -1,0 +1,97 @@
+require('dotenv').config()
+const { ApiPromise, WsProvider, Keyring } = require('@polkadot/api')
+const BN = require('bn.js');
+const bn1e12 = new BN(10).pow(new BN(12));
+
+const PHA_ON_KHALA = '0x010100511f';
+const PHA_ON_ETHEREUM = '0xB376b0Ee6d8202721838e76376e81eEc0e2FE864';
+const WETH_ON_ETHEREUM = '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6';
+const WORKER_PUBKEY = '0x2eaaf908adda6391e434ff959973019fb374af1076edd4fec55b5e6018b1a955'
+
+/******** OperationJson definition in Rust **************
+struct OperationJson {
+    op_type: String,
+    source_chain: String,
+    dest_chain: String,
+    spend_asset: Address,
+    receive_asset: Address,
+    dex: String,
+    fee: String,
+    cap: String,
+    flow: String,
+    impact: String,
+    spend: String,
+}
+******************************************************/
+
+function createRequest() {
+  let operations = [
+    {
+      op_type: 'bridge',
+      source_chain: 'Khala',
+      dest_chain: 'Ethereum',
+      spend_asset: PHA_ON_KHALA,
+      receive_asset: PHA_ON_ETHEREUM,
+      dex: 'null',
+      fee: '300',
+      cap: '0',
+      flow: '301000000000000',
+      impact: '0',
+      // 1 PHA will be briged, with decimals 12
+      spend: '301000000000000',
+    },
+    {
+        op_type: 'swap',
+        source_chain: 'Ethereum',
+        dest_chain: 'Ethereum',
+        spend_asset: PHA_ON_ETHEREUM,
+        receive_asset: WETH_ON_ETHEREUM,
+        dex: 'UniswapV2',
+        fee: '0',
+        cap: '0',
+        flow: '1000000000000000000',
+        impact: '0',
+        // 1 PHA with decimals 18
+        spend: '1000000000000000000',
+      },
+  ]
+  return JSON.stringify(operations)
+}
+
+function getPhaAssetId(api) {
+    return api.createType('XcmV1MultiassetAssetId', {
+        Concrete: api.createType('XcmV1MultiLocation', {
+            parents: 0,
+            interior: api.createType('Junctions', 'Here')
+        })
+    })
+}
+
+async function main() {
+    const api = await ApiPromise.create({
+        provider: new WsProvider(process.env.ENDPOINT || 'ws://localhost:9944'),
+    });
+    const alice = new Keyring({ type: 'sr25519' }).addFromUri('//Alice');
+
+    const unsub = await api.tx.palletIndex.depositTask(
+        getPhaAssetId(api),
+        api.createType('Compact<U128>', bn1e12.mul(new BN(301))),
+        // Recipient address on Ethereum
+        '0xA29D4E0F035cb50C0d78c8CeBb56Ca292616Ab20',
+        WORKER_PUBKEY,
+        // Request id
+        '0x0000000000000000000000000000000000000000000000000000000000000001',
+        createRequest()
+    ).signAndSend(alice, (result) => {
+        if (result.status.isInBlock) {
+            console.log(`Transaction included at blockHash ${result.status.asInBlock}`);
+        } else if (result.status.isFinalized) {
+            console.log(`Transaction finalized at blockHash ${result.status.asFinalized}`);
+            unsub();
+        }
+    });
+}
+
+main()
+  .catch(console.error)
+  .finally(() => process.exit())


### PR DESCRIPTION
The workflow is:
- admin of khala/phala call PalletIndex::force_add_work() to whitelist worker
- user call PalletIndex::deposit_task() to deposit their task
- inDEX engine query activated task through on-chain storage
- inDEX engine call PalletIndex::claim_task() to claim task (including transfer asset from pallet account to worker account on behalf)