### PR TITLE
Fix executor type definition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2101,7 +2101,7 @@ dependencies = [
 [[package]]
 name = "phat_offchain_rollup"
 version = "0.1.0"
-source = "git+https://github.com/Phala-Network/phat-offchain-rollup.git?branch=ink4.0#a1ae83dbaef3c91ab83158635fc4df8c63acb354"
+source = "git+https://github.com/Phala-Network/phat-offchain-rollup.git?branch=main#7609bfc7e153308d0063299e8b842bae9e6f1063"
 dependencies = [
  "ethabi",
  "hex",
@@ -3722,9 +3722,9 @@ checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.6"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08de71aa0d6e348f070457f85af8bd566e2bc452156a423ddf22861b3a953fae"
+checksum = "dc18466501acd8ac6a3f615dd29a3438f8ca6bb3b19537138b3106e575621274"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -4218,9 +4218,9 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winnow"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee7b2c67f962bf5042bfd8b6a916178df33a26eec343ae064cb8e069f638fa6f"
+checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
 dependencies = [
  "memchr",
 ]

--- a/contracts/index_executor/Cargo.toml
+++ b/contracts/index_executor/Cargo.toml
@@ -22,7 +22,7 @@ scale = { package = "parity-scale-codec", version = "3.1", default-features = fa
 scale-info = { version = "2.1", default-features = false, features = ["derive"], optional = true }
 xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29", default-features = false }
 phala-pallet-common = { git = "https://github.com/Phala-Network/khala-parachain", tag = "v0.1.18", default-features = false }
-phat_offchain_rollup = { git = "https://github.com/Phala-Network/phat-offchain-rollup.git", branch = "ink4.0", default-features = false, features = ["substrate"] }
+phat_offchain_rollup = { git = "https://github.com/Phala-Network/phat-offchain-rollup.git", branch = "main", default-features = false, features = ["substrate"] }
 pink-kv-session = { version = "0.2.0", default-features = false }
 pink-extension = { version = "0.4.1", default-features = false }
 pink-web3 = { version = "0.20.1", git = "https://github.com/Phala-Network/pink-web3.git", branch = "pink", default-features = false, features = ["pink"]}
@@ -36,7 +36,7 @@ hex-literal = "0.3"
 pink-extension-runtime = "0.4.0"
 dotenv = "0.15.0"
 hex = "0.4.3"
-phat_offchain_rollup = { git = "https://github.com/Phala-Network/phat-offchain-rollup.git", branch = "ink4.0", default-features = false, features = ["substrate", "logging"] }
+phat_offchain_rollup = { git = "https://github.com/Phala-Network/phat-offchain-rollup.git", branch = "main", default-features = false, features = ["substrate", "logging"] }
 
 [profile.release]
 overflow-checks = false     # Disable integer overflow checks.

--- a/contracts/index_executor/src/lib.rs
+++ b/contracts/index_executor/src/lib.rs
@@ -602,7 +602,7 @@ mod index_executor {
             // Moonbeam -> Acala
             bridge_executors.push((
                 (String::from("Moonbeam"), String::from("Acala")),
-                Box::new(Moonbeam2AcalaExecutor::new(
+                Box::new(MoonbeamXTokenExecutor::new(
                     &moonbeam.endpoint,
                     moonbeam_xtoken.into(),
                     ACALA_PARACHAIN_ID,
@@ -611,7 +611,7 @@ mod index_executor {
             // Moonbeam -> Phala
             bridge_executors.push((
                 (String::from("Moonbeam"), String::from("Phala")),
-                Box::new(Moonbeam2PhalaExecutor::new(
+                Box::new(MoonbeamXTokenExecutor::new(
                     &moonbeam.endpoint,
                     moonbeam_xtoken.into(),
                     PHALA_PARACHAIN_ID,
@@ -620,7 +620,7 @@ mod index_executor {
             // Phala -> Acala
             bridge_executors.push((
                 (String::from("Phala"), String::from("Acala")),
-                Box::new(Phala2AcalaExecutor::new(
+                Box::new(PhalaXTransferExecutor::new(
                     &phala.endpoint,
                     ACALA_PARACHAIN_ID,
                     index::AccountType::Account32,

--- a/index/Cargo.lock
+++ b/index/Cargo.lock
@@ -3238,9 +3238,9 @@ checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.6"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08de71aa0d6e348f070457f85af8bd566e2bc452156a423ddf22861b3a953fae"
+checksum = "dc18466501acd8ac6a3f615dd29a3438f8ca6bb3b19537138b3106e575621274"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -3728,9 +3728,9 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winnow"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee7b2c67f962bf5042bfd8b6a916178df33a26eec343ae064cb8e069f638fa6f"
+checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
 dependencies = [
  "memchr",
 ]

--- a/index/src/executors/bridge_executors/moonbeam_xtoken.rs
+++ b/index/src/executors/bridge_executors/moonbeam_xtoken.rs
@@ -12,9 +12,6 @@ use pink_web3::{
     transports::PinkHttp,
 };
 
-pub type Moonbeam2AcalaExecutor = MoonbeamXTokenExecutor;
-pub type Moonbeam2PhalaExecutor = MoonbeamXTokenExecutor;
-
 #[derive(Clone)]
 pub struct MoonbeamXTokenExecutor {
     bridge_contract: XtokenClient,
@@ -119,7 +116,7 @@ mod tests {
     fn moonbeam_to_acala_xcdot() {
         pink_extension_runtime::mock_ext::mock_all_ext();
 
-        let exec = Moonbeam2AcalaExecutor::new(
+        let exec = MoonbeamXTokenExecutor::new(
             "https://moonbeam.public.blastapi.io",
             H160::from_str("0x0000000000000000000000000000000000000804").unwrap(),
             ACALA_PARACHAIN_ID,

--- a/index/src/executors/bridge_executors/phala_xtransfer.rs
+++ b/index/src/executors/bridge_executors/phala_xtransfer.rs
@@ -11,9 +11,6 @@ use scale::Decode;
 
 use xcm::v1::{prelude::*, AssetId, Fungibility, Junctions, MultiAsset, MultiLocation};
 
-pub type Phala2AcalaExecutor = PhalaXTransferExecutor;
-pub type Phala2MoonbeamExecutor = PhalaXTransferExecutor;
-
 #[derive(Clone)]
 pub struct PhalaXTransferExecutor {
     rpc: String,

--- a/index/src/prelude.rs
+++ b/index/src/prelude.rs
@@ -1,7 +1,6 @@
 pub use super::executors::bridge_executors::{
-    ethereum_to_phala::ChainBridgeEthereum2Phala, moonbeam_xtoken::Moonbeam2AcalaExecutor,
-    moonbeam_xtoken::Moonbeam2PhalaExecutor, phala_to_ethereum::ChainBridgePhala2Ethereum,
-    phala_xtransfer::Phala2AcalaExecutor,
+    ethereum_to_phala::ChainBridgeEthereum2Phala, moonbeam_xtoken::MoonbeamXTokenExecutor,
+    phala_to_ethereum::ChainBridgePhala2Ethereum, phala_xtransfer::PhalaXTransferExecutor,
 };
 pub use super::executors::dex_executors::{
     acala_dot_swap::AcalaDotSwapExecutor, acala_swap::AcalaDexExecutor,


### PR DESCRIPTION
Previously, to create a moonbeam-to-acala executor, a grammar like this was employed:

```rust
let exec = Moonbeam2AcalaExecutor::new(
            "https://moonbeam.public.blastapi.io",
            H160::from_str("0x0000000000000000000000000000000000000804").unwrap(),
            ACALA_PARACHAIN_ID,)
```

however, it has some logic defects, if the type `Moonbeam2AcalaExecutor` is sufficient, its `new()` function should not require these 2 arguments: `ACALA_PARACHAIN_ID` and `xtoken_address`, they should be hardcoded as the struct name has identified itself to serve one purpose only: transferring things from moonbeam to acala

that is to say, if we don't want to hardcode arguments, then we have to change the struct names. This PR aims to remove executor type aliases.



