### PR TITLE
Fix multiple workers run&scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,6 +1358,7 @@ dependencies = [
  "index",
  "ink",
  "ink_env",
+ "key_store",
  "parity-scale-codec",
  "phala-pallet-common",
  "phat_offchain_rollup",
@@ -1653,6 +1654,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "key_store"
+version = "0.1.0"
+dependencies = [
+ "dotenv",
+ "index",
+ "ink",
+ "ink_env",
+ "parity-scale-codec",
+ "pink-extension",
+ "pink-extension-runtime",
+ "pink-web3 0.20.1 (git+https://github.com/Phala-Network/pink-web3.git?branch=pink)",
+ "scale-info",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2118,7 +2118,7 @@ dependencies = [
 [[package]]
 name = "phat_offchain_rollup"
 version = "0.1.0"
-source = "git+https://github.com/Phala-Network/phat-offchain-rollup.git?branch=main#7609bfc7e153308d0063299e8b842bae9e6f1063"
+source = "git+https://github.com/Phala-Network/phat-offchain-rollup.git?branch=main#25fec0b376b5454c966b14fcf496172f1d1e846e"
 dependencies = [
  "ethabi",
  "hex",
@@ -3872,7 +3872,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.6",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,7 +1661,6 @@ name = "key_store"
 version = "0.1.0"
 dependencies = [
  "dotenv",
- "index",
  "ink",
  "ink_env",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "examples/semi_bridge",
     "examples/system_remark",
     "contracts/index_executor",
+    "contracts/key_store",
 ]
 
 exclude = [

--- a/contracts/index_executor/Cargo.toml
+++ b/contracts/index_executor/Cargo.toml
@@ -29,6 +29,7 @@ pink-web3 = { version = "0.20.1", git = "https://github.com/Phala-Network/pink-w
 pink-json = { git = "https://github.com/Phala-Network/pink-json.git", branch = "pink", default-features = false, features = ["custom-error-messages"] }
 pink-subrpc = { version = "0.4.2", default-features = false }
 index = { path = "../../index", default-features = false }
+key_store = { path = "../key_store", default-features = false, features = ["ink-as-dependency"] }
 
 [dev-dependencies]
 env_logger = "0.10.0"
@@ -70,6 +71,7 @@ std = [
     "pink-json/std",
     "pink-subrpc/std",
     "index/std",
+    "key_store/std",
     "sp-std/std",
 ]
 ink-as-dependency = []

--- a/contracts/index_executor/Cargo.toml
+++ b/contracts/index_executor/Cargo.toml
@@ -29,7 +29,7 @@ pink-web3 = { version = "0.20.1", git = "https://github.com/Phala-Network/pink-w
 pink-json = { git = "https://github.com/Phala-Network/pink-json.git", branch = "pink", default-features = false, features = ["custom-error-messages"] }
 pink-subrpc = { version = "0.4.2", default-features = false }
 index = { path = "../../index", default-features = false }
-key_store = { path = "../key_store", default-features = false, features = ["ink-as-dependency"] }
+worker_key_store = { package = "key_store", path = "../key_store", default-features = false, features = ["ink-as-dependency"] }
 
 [dev-dependencies]
 env_logger = "0.10.0"
@@ -71,7 +71,7 @@ std = [
     "pink-json/std",
     "pink-subrpc/std",
     "index/std",
-    "key_store/std",
+    "worker_key_store/std",
     "sp-std/std",
 ]
 ink-as-dependency = []

--- a/contracts/index_executor/src/abi/erc20.json
+++ b/contracts/index_executor/src/abi/erc20.json
@@ -1,0 +1,156 @@
+[
+    {
+        "type": "function",
+        "name": "name",
+        "constant": true,
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "string"
+            }
+        ]
+    },
+    {
+        "type": "function",
+        "name": "decimals",
+        "constant": true,
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint8"
+            }
+        ]
+    },
+    {
+        "type": "function",
+        "name": "balanceOf",
+        "constant": true,
+        "inputs": [
+            {
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256"
+            }
+        ]
+    },
+    {
+        "type": "function",
+        "name": "symbol",
+        "constant": true,
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "string"
+            }
+        ]
+    },
+    {
+        "type": "function",
+        "name": "transfer",
+        "constant": false,
+        "inputs": [
+            {
+                "name": "_to",
+                "type": "address"
+            },
+            {
+                "name": "_value",
+                "type": "uint256"
+            }
+        ],
+        "outputs": []
+    },
+    {
+        "type": "constructor",
+        "inputs": [
+            {
+                "name": "_supply",
+                "type": "uint256"
+            },
+            {
+                "name": "_name",
+                "type": "string"
+            },
+            {
+                "name": "_decimals",
+                "type": "uint8"
+            },
+            {
+                "name": "_symbol",
+                "type": "string"
+            }
+        ]
+    },
+    {
+        "name": "Transfer",
+        "type": "event",
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "name": "from",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "name": "value",
+                "type": "uint256"
+            }
+        ]
+    },
+   {
+      "constant":false,
+      "inputs":[
+         {
+            "name":"_spender",
+            "type":"address"
+         },
+         {
+            "name":"_value",
+            "type":"uint256"
+         }
+      ],
+      "name":"approve",
+      "outputs":[
+         {
+            "name":"success",
+            "type":"bool"
+         }
+      ],
+      "type":"function"
+   },
+   {
+      "constant":true,
+      "inputs":[
+         {
+            "name":"",
+            "type":"address"
+         },
+         {
+            "name":"",
+            "type":"address"
+         }
+      ],
+      "name":"allowance",
+      "outputs":[
+         {
+            "name":"",
+            "type":"uint256"
+         }
+      ],
+      "type":"function"
+   }
+]

--- a/contracts/index_executor/src/gov.rs
+++ b/contracts/index_executor/src/gov.rs
@@ -1,0 +1,94 @@
+use alloc::string::String;
+use alloc::vec::Vec;
+use pink_web3::{
+    api::{Eth, Namespace},
+    contract::{Contract, Options},
+    keys::pink::KeyPair,
+    signing::Key,
+    transports::{resolve_ready, PinkHttp},
+    types::{Address, U256},
+};
+
+pub struct WorkerGov;
+
+impl WorkerGov {
+    pub fn erc20_approve(
+        worker_key: [u8; 32],
+        endpoint: String,
+        token: Address,
+        spender: Address,
+        amount: u128,
+    ) -> Result<Vec<u8>, &'static str> {
+        let transport = Eth::new(PinkHttp::new(endpoint));
+        let erc20_token = Contract::from_json(transport, token, include_bytes!("./abi/erc20.json"))
+            .or(Err("ConstructContractFailed"))?;
+        let worker = KeyPair::from(worker_key);
+
+        // Estiamte gas before submission
+        let gas = resolve_ready(erc20_token.estimate_gas(
+            "approve",
+            (spender, U256::from(amount)),
+            worker.address(),
+            Options::default(),
+        ))
+        .or(Err("GasEstimateFailed"))?;
+
+        // Submit the `approve` transaction
+        let tx_id = resolve_ready(erc20_token.signed_call(
+            "approve",
+            (spender, U256::from(amount)),
+            Options::with(|opt| {
+                opt.gas = Some(gas);
+            }),
+            worker,
+        ))
+        .or(Err("ERC20ApproveSubmitFailed"))?;
+        pink_extension::info!(
+            "Submit transaction to do ERC20 approve, token {:?} , spender ${:?}, amount: {:?}, tx id: {:?}",
+            hex::encode(token),
+            hex::encode(spender),
+            amount,
+            hex::encode(tx_id.clone().as_bytes())
+        );
+
+        Ok(tx_id.as_bytes().to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::String;
+    use dotenv::dotenv;
+    use hex_literal::hex;
+    use index::utils::ToArray;
+    use pink_web3::types::H160;
+
+    #[test]
+    #[ignore]
+    fn test_worker_approve() {
+        dotenv().ok();
+        pink_extension_runtime::mock_ext::mock_all_ext();
+
+        let secret_key = std::env::vars().find(|x| x.0 == "SECRET_KEY");
+        let secret_key = secret_key.unwrap().1;
+        let secret_bytes = hex::decode(secret_key).unwrap();
+        let signer: [u8; 32] = secret_bytes.to_array();
+        let pha_on_goerli: H160 = hex!("b376b0ee6d8202721838e76376e81eec0e2fe864").into();
+        let spender: H160 = hex!("ffffffffffffffffffffffffffffffffffffffff").into();
+
+        // Issue command: SECRET_KEY=<private key> cargo test --package index_executor --lib -- gov::tests::test_worker_approve --exact --nocapture
+        // Send approve transaction
+        // https://goerli.etherscan.io/tx/0x6d711af99d4836c8febe3d27e14bc0ad9b8353d89ebcae3f465a6cc70519e35c
+        let tx_id = WorkerGov::erc20_approve(
+            signer,
+            String::from("https://eth-goerli.g.alchemy.com/v2/lLqSMX_1unN9Xrdy_BB9LLZRgbrXwZv2"),
+            pha_on_goerli,
+            spender,
+            // 100 PHA
+            100_000_000_000_000_000_000_u128,
+        )
+        .unwrap();
+        dbg!("Approve transaction: {:?}", hex::encode(tx_id));
+    }
+}

--- a/contracts/index_executor/src/lib.rs
+++ b/contracts/index_executor/src/lib.rs
@@ -31,12 +31,12 @@ mod index_executor {
     };
     use ink::storage::traits::StorageLayout;
     use ink_env::call::FromAccountId;
-    use key_store::KeyStoreRef;
     use phat_offchain_rollup::clients::substrate::{
         claim_name, get_name_owner, SubstrateRollupClient,
     };
     use pink_extension::ResultExt;
     use scale::{Decode, Encode};
+    use worker_key_store::KeyStoreRef;
 
     #[derive(Encode, Decode, Debug, PartialEq, Eq)]
     #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
@@ -807,7 +807,7 @@ mod index_executor {
             let mut executor = deploy_executor();
             // Initial rollup
             assert_eq!(
-                executor.config(100, String::from("http://127.0.0.1:39933")),
+                executor.config(100, String::from("http://127.0.0.1:39933"), [0; 32].into()),
                 Ok(())
             );
             assert_eq!(executor.setup_rollup(), Ok(()));
@@ -848,7 +848,7 @@ mod index_executor {
                 .unwrap();
             // Initial rollup
             assert_eq!(
-                executor.config(100, String::from("http://127.0.0.1:39933")),
+                executor.config(100, String::from("http://127.0.0.1:39933"), [0; 32].into()),
                 Ok(())
             );
             assert_eq!(executor.setup_rollup(), Ok(()));

--- a/contracts/index_executor/src/lib.rs
+++ b/contracts/index_executor/src/lib.rs
@@ -290,7 +290,7 @@ mod index_executor {
         }
 
         #[ink(message)]
-        pub fn unpause_executor(&mut self) -> Result<()> {
+        pub fn resume_executor(&mut self) -> Result<()> {
             self.ensure_owner()?;
             self.ensure_paused()?;
             self.is_paused = false;

--- a/contracts/index_executor/src/lib.rs
+++ b/contracts/index_executor/src/lib.rs
@@ -381,7 +381,7 @@ mod index_executor {
         /// Return executor status
         #[ink(message)]
         pub fn is_running(&self) -> Result<bool> {
-            Ok(self.is_paused == false)
+            Ok(!self.is_paused)
         }
 
         /// For cross-contract call test

--- a/contracts/index_executor/src/lib.rs
+++ b/contracts/index_executor/src/lib.rs
@@ -335,7 +335,6 @@ mod index_executor {
             self.ensure_graph_set()?;
 
             let config = self.ensure_configured()?;
-            pink_extension::debug!("Runing check passed, start to run");
             let contract_id = self.env().account_id();
             let mut client = SubstrateRollupClient::new(
                 &config.rollup_endpoint,
@@ -348,7 +347,6 @@ mod index_executor {
 
             match running_type {
                 RunningType::Fetch(source_chain, worker) => {
-                    pink_extension::debug!("Runing type: fetch");
                     self.fetch_task(&mut client, source_chain, worker)?
                 }
                 RunningType::Execute => self.execute_task(&mut client)?,
@@ -445,8 +443,6 @@ mod index_executor {
             // Worker sr25519 public key
             worker: [u8; 32],
         ) -> Result<()> {
-            pink_extension::debug!("Fetch actived task from {:?}, chain ifno: ${:?}", &source_chain, self.get_chain(source_chain.clone())
-            .ok_or(Error::ChainNotFound)?);
             // Fetch one actived task that completed initial confirmation from specific chain that belong to current worker
             let actived_task = ActivedTaskFetcher::new(
                 self.get_chain(source_chain.clone())

--- a/contracts/index_executor/src/lib.rs
+++ b/contracts/index_executor/src/lib.rs
@@ -335,6 +335,7 @@ mod index_executor {
             self.ensure_graph_set()?;
 
             let config = self.ensure_configured()?;
+            pink_extension::debug!("Runing check passed, start to run");
             let contract_id = self.env().account_id();
             let mut client = SubstrateRollupClient::new(
                 &config.rollup_endpoint,
@@ -347,6 +348,7 @@ mod index_executor {
 
             match running_type {
                 RunningType::Fetch(source_chain, worker) => {
+                    pink_extension::debug!("Runing type: fetch");
                     self.fetch_task(&mut client, source_chain, worker)?
                 }
                 RunningType::Execute => self.execute_task(&mut client)?,
@@ -376,6 +378,12 @@ mod index_executor {
         #[ink(message)]
         pub fn get_config(&self) -> Result<Option<Config>> {
             Ok(self.config.clone())
+        }
+
+        /// Return executor status
+        #[ink(message)]
+        pub fn is_running(&self) -> Result<bool> {
+            Ok(self.is_paused == false)
         }
 
         /// For cross-contract call test
@@ -437,7 +445,8 @@ mod index_executor {
             // Worker sr25519 public key
             worker: [u8; 32],
         ) -> Result<()> {
-            pink_extension::debug!("Fetch actived task from {:?}", &source_chain);
+            pink_extension::debug!("Fetch actived task from {:?}, chain ifno: ${:?}", &source_chain, self.get_chain(source_chain.clone())
+            .ok_or(Error::ChainNotFound)?);
             // Fetch one actived task that completed initial confirmation from specific chain that belong to current worker
             let actived_task = ActivedTaskFetcher::new(
                 self.get_chain(source_chain.clone())

--- a/contracts/index_executor/src/steps/claimer.rs
+++ b/contracts/index_executor/src/steps/claimer.rs
@@ -262,7 +262,7 @@ impl ActivedTaskFetcher {
             &evm_deposit_data,
         );
         let deposit_data: DepositData = evm_deposit_data.into();
-        let task = deposit_data.to_task(&chain.name, task_id)?;
+        let task = deposit_data.to_task(&chain.name, task_id, self.worker.account32)?;
         Ok(Some(task))
     }
 
@@ -309,7 +309,8 @@ impl ActivedTaskFetcher {
                         &sub_deposit_data,
                     );
                     let deposit_data: DepositData = sub_deposit_data.into();
-                    let task = deposit_data.to_task(&chain.name, oldest_task)?;
+                    let task =
+                        deposit_data.to_task(&chain.name, oldest_task, self.worker.account32)?;
                     Ok(Some(task))
                 } else {
                     Err("DepositInfoNotFound")
@@ -417,7 +418,12 @@ impl From<SubDepositData> for DepositData {
 }
 
 impl DepositData {
-    fn to_task(&self, source_chain: &str, id: [u8; 32]) -> Result<Task, &'static str> {
+    fn to_task(
+        &self,
+        source_chain: &str,
+        id: [u8; 32],
+        worker: [u8; 32],
+    ) -> Result<Task, &'static str> {
         pink_extension::debug!("Trying to parse task data from json string");
         let task_data_json: TaskDataJson =
             pink_json::from_str(&self.task).map_err(|_| "InvalidTask")?;
@@ -435,6 +441,7 @@ impl DepositData {
             source: source_chain.into(),
             sender: self.sender.clone(),
             recipient: self.recipient.clone(),
+            worker,
             ..Default::default()
         };
 

--- a/contracts/index_executor/src/task.rs
+++ b/contracts/index_executor/src/task.rs
@@ -77,24 +77,35 @@ impl Task {
             // Task already saved, return
             return Ok(());
         }
-        if let Some(account) = free_accounts.pop() {
-            // Apply a worker account
-            self.worker = account;
-            // Apply worker nonce for each step in task
-            self.apply_nonce(context, client)?;
-            // Apply recipient for each step in task
-            self.apply_recipient(context)?;
-            // TODO: query initial balance of worker account and setup to specific step
-            self.status = TaskStatus::Initialized;
-            self.execute_index = 0;
-            // Push to pending tasks queue
-            pending_tasks.push(self.id);
-            // Save task data
-            client.session().put(self.id.as_ref(), self.encode());
+
+        // Lookup free worker list to find if the worker we expected is free, if it's free remove it or return error
+        if let Some(index) = free_accounts.iter().position(|&x| x == self.worker) {
+            free_accounts.remove(index);
+            pink_extension::debug!(
+                "Worker {:?} is free, will be applied to this task {:?}.",
+                hex::encode(self.worker),
+                hex::encode(self.id)
+            );
         } else {
-            // We can not handle more tasks any more
-            return Ok(());
+            pink_extension::debug!(
+                "Worker {:?} is busy, try again later for this task {:?}.",
+                hex::encode(self.worker),
+                hex::encode(self.id)
+            );
+            return Err("WorkerIsBusy");
         }
+
+        // Apply worker nonce for each step in task
+        self.apply_nonce(context, client)?;
+        // Apply recipient for each step in task
+        self.apply_recipient(context)?;
+        // TODO: query initial balance of worker account and setup to specific step
+        self.status = TaskStatus::Initialized;
+        self.execute_index = 0;
+        // Push to pending tasks queue
+        pending_tasks.push(self.id);
+        // Save task data
+        client.session().put(self.id.as_ref(), self.encode());
 
         client
             .session()

--- a/contracts/index_executor/src/task.rs
+++ b/contracts/index_executor/src/task.rs
@@ -475,10 +475,9 @@ impl OnchainAccounts {
     /// Return worker account that hasn't been allocated yet. Return `Nonce` if not set in rollup storage.
     pub fn lookup_free_accounts(client: &mut SubstrateRollupClient) -> Option<Vec<[u8; 32]>> {
         if let Ok(Some(raw_accounts)) = client.session().get(b"free_accounts".as_ref()) {
-            return match Decode::decode(&mut raw_accounts.as_slice()) {
-                Ok(free_accounts) => free_accounts,
-                Err(_) => None,
-            };
+            let free_accounts: Option<Vec<[u8; 32]>> =
+                Decode::decode(&mut raw_accounts.as_slice()).ok();
+            return free_accounts;
         }
         None
     }

--- a/contracts/key_store/Cargo.toml
+++ b/contracts/key_store/Cargo.toml
@@ -15,7 +15,7 @@ scale = { package = "parity-scale-codec", version = "3.1", default-features = fa
 scale-info = { version = "2.1", default-features = false, features = ["derive"], optional = true }
 
 pink-extension = { version = "0.4.1", default-features = false }
-pink-web3 = { version = "0.20.1", git = "https://github.com/Phala-Network/pink-web3.git", branch = "pink", default-features = false, features = ["pink"]}
+pink-web3 = { version = "0.20.1", git = "https://github.com/Phala-Network/pink-web3.git", branch = "pink", default-features = false, features = ["pink", "signing"]}
 
 [dev-dependencies]
 pink-extension-runtime = "0.4.0"

--- a/contracts/key_store/Cargo.toml
+++ b/contracts/key_store/Cargo.toml
@@ -1,0 +1,55 @@
+[package]
+name = "key_store"
+version = "0.1.0"
+authors = ["Phala Network"]
+edition = "2021"
+license = "Apache 2.0"
+homepage = "https://phala.network/"
+repository = "https://github.com/Phala-Network/index-contract"
+
+[dependencies]
+serde = { version = "1.0.140", default-features = false, features = ["derive", "alloc"]}
+ink = { version = "4.0.1", default-features = false }
+ink_env = { version = "4.0.1", default-features = false }
+scale = { package = "parity-scale-codec", version = "3.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.1", default-features = false, features = ["derive"], optional = true }
+
+pink-extension = { version = "0.4.1", default-features = false }
+pink-web3 = { version = "0.20.1", git = "https://github.com/Phala-Network/pink-web3.git", branch = "pink", default-features = false, features = ["pink"]}
+
+index = { path = "../../index", default-features = false }
+
+[dev-dependencies]
+pink-extension-runtime = "0.4.0"
+dotenv = "0.15.0"
+
+[profile.release]
+overflow-checks = false     # Disable integer overflow checks.
+lto = false  
+
+[lib]
+name = "key_store"
+path = "src/lib.rs"
+crate-type = [
+	# Used for normal contract Wasm blobs.
+	"cdylib",
+    # Used for ABI generation.
+    "rlib",
+]
+
+[features]
+default = ["std"]
+std = [
+    "serde/std",
+    "ink/std",
+    "ink_env/std",
+    "scale/std",
+    "scale-info/std",
+    "pink-extension/std",
+    "pink-web3/std",
+    "index/std",
+]
+ink-as-dependency = []
+
+[patch.crates-io]
+serde = { git = "https://github.com/kvinwang/serde.git", branch = "pink" }

--- a/contracts/key_store/Cargo.toml
+++ b/contracts/key_store/Cargo.toml
@@ -17,8 +17,6 @@ scale-info = { version = "2.1", default-features = false, features = ["derive"],
 pink-extension = { version = "0.4.1", default-features = false }
 pink-web3 = { version = "0.20.1", git = "https://github.com/Phala-Network/pink-web3.git", branch = "pink", default-features = false, features = ["pink"]}
 
-index = { path = "../../index", default-features = false }
-
 [dev-dependencies]
 pink-extension-runtime = "0.4.0"
 dotenv = "0.15.0"
@@ -47,7 +45,6 @@ std = [
     "scale-info/std",
     "pink-extension/std",
     "pink-web3/std",
-    "index/std",
 ]
 ink-as-dependency = []
 

--- a/contracts/key_store/src/lib.rs
+++ b/contracts/key_store/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-pub use key_store::{KeyStore, KeyStoreRef};
+pub use crate::key_store::{KeyStore, KeyStoreRef};
 
 #[ink::contract(env = pink_extension::PinkEnvironment)]
 mod key_store {

--- a/contracts/key_store/src/lib.rs
+++ b/contracts/key_store/src/lib.rs
@@ -66,7 +66,7 @@ mod key_store {
             Ok(())
         }
 
-        /// Only whitelisted executors are allowed to call this function
+        /// Only the whitelisted executor are allowed to call this function
         #[ink(message)]
         pub fn get_worker_keys(&self) -> Result<Vec<[u8; 32]>> {
             self.ensure_executor()?;

--- a/contracts/key_store/src/lib.rs
+++ b/contracts/key_store/src/lib.rs
@@ -1,0 +1,130 @@
+#![cfg_attr(not(any(feature = "std", test)), no_std)]
+
+extern crate alloc;
+
+pub use key_store::{KeyStore, KeyStoreRef};
+
+#[ink::contract(env = pink_extension::PinkEnvironment)]
+mod key_store {
+    use alloc::{vec, vec::Vec};
+    use index::utils::ToArray;
+    use ink::storage::traits::StorageLayout;
+    use pink_extension::chain_extension::{signing, SigType};
+    use scale::{Decode, Encode};
+
+    #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout,))]
+    pub struct AccountInfo {
+        pub account32: [u8; 32],
+        pub account20: [u8; 20],
+    }
+
+    impl From<[u8; 32]> for AccountInfo {
+        fn from(privkey: [u8; 32]) -> Self {
+            let ecdsa_pubkey: [u8; 33] = signing::get_public_key(&privkey, SigType::Ecdsa)
+                .try_into()
+                .expect("Public key should be of length 33");
+            let mut ecdsa_address = [0u8; 20];
+            ink_env::ecdsa_to_eth_address(&ecdsa_pubkey, &mut ecdsa_address)
+                .expect("Get address of ecdsa failed");
+            Self {
+                account32: signing::get_public_key(&privkey, SigType::Sr25519).to_array(),
+                account20: ecdsa_address,
+            }
+        }
+    }
+
+    #[derive(Encode, Decode, Debug, PartialEq, Eq)]
+    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+    pub enum Error {
+        BadOrigin,
+        MissingExecutor,
+    }
+
+    type Result<T> = core::result::Result<T, Error>;
+
+    #[ink(storage)]
+    pub struct KeyStore {
+        pub admin: AccountId,
+        pub prv_keys: Vec<[u8; 32]>,
+        pub executor: Option<AccountId>,
+    }
+
+    impl Default for KeyStore {
+        fn default() -> Self {
+            Self::default()
+        }
+    }
+
+    impl KeyStore {
+        #[allow(clippy::should_implement_trait)]
+        #[ink(constructor)]
+        pub fn default() -> Self {
+            let mut prv_keys: Vec<[u8; 32]> = vec![];
+
+            for index in 0..5 {
+                let private_key = pink_web3::keys::pink::KeyPair::derive_keypair(
+                    &[b"worker".to_vec(), [index].to_vec()].concat(),
+                )
+                .private_key();
+                prv_keys.push(private_key);
+            }
+
+            Self {
+                admin: Self::env().caller(),
+                prv_keys,
+                executor: None,
+            }
+        }
+
+        #[ink(message)]
+        pub fn set_executor(&mut self, executor: AccountId) -> Result<()> {
+            self.ensure_owner()?;
+            self.executor = Some(executor);
+            Ok(())
+        }
+
+        #[ink(message)]
+        pub fn remove_executor(&mut self) -> Result<()> {
+            self.ensure_owner()?;
+            self.executor = None;
+            Ok(())
+        }
+
+        #[ink(message)]
+        pub fn get_worker_keys(&self) -> Result<Vec<[u8; 32]>> {
+            self.ensure_executor()?;
+            Ok(self.prv_keys.clone())
+        }
+
+        #[ink(message)]
+        pub fn get_worker_accounts(&self) -> Result<Vec<AccountInfo>> {
+            let mut accounts: Vec<AccountInfo> = vec![];
+
+            for key in self.prv_keys.iter() {
+                accounts.push(AccountInfo::from(*key))
+            }
+
+            Ok(accounts.clone())
+        }
+
+        /// Returns BadOrigin error if the caller is not the owner
+        fn ensure_owner(&self) -> Result<()> {
+            if self.env().caller() == self.admin {
+                Ok(())
+            } else {
+                Err(Error::BadOrigin)
+            }
+        }
+
+        /// Returns BadOrigin error if the caller is not the owner
+        fn ensure_executor(&self) -> Result<()> {
+            let executor = self.executor.ok_or(Error::MissingExecutor)?;
+            if self.env().caller() == executor {
+                Ok(())
+            } else {
+                Err(Error::BadOrigin)
+            }
+        }
+    }
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -8,10 +8,16 @@
   "author": "",
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@phala/sdk": "^0.3.8-beta.0",
-    "@polkadot/api": "^9.13.6",
-    "@polkadot/api-contract": "^9.13.6",
+    "@phala/sdk": "^0.4.0",
+    "@phala/typedefs": "^0.2.33",
+    "@polkadot/api": "^10.2.2",
+    "@polkadot/api-contract": "^10.2.2",
+    "@polkadot/types-support": "^10.2.1",
     "bn.js": "^5.2.1",
-    "console-stamp": "^3.1.0"
+    "commander": "^10.0.0",
+    "console-stamp": "^3.1.0",
+    "decimal.js": "^10.4.3",
+    "dotenv": "^16.0.3",
+    "ethers": "^6.2.3"
   }
 }

--- a/scripts/src/ERC20ABI.json
+++ b/scripts/src/ERC20ABI.json
@@ -1,0 +1,663 @@
+[
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "symbol",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "Paused",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "previousAdminRole",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "newAdminRole",
+          "type": "bytes32"
+        }
+      ],
+      "name": "RoleAdminChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "RoleGranted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "RoleRevoked",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "Unpaused",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "DEFAULT_ADMIN_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "MINTER_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "PAUSER_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "allowance",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "approve",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "burn",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "burnFrom",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "subtractedValue",
+          "type": "uint256"
+        }
+      ],
+      "name": "decreaseAllowance",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getRoleAdmin",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256",
+          "name": "index",
+          "type": "uint256"
+        }
+      ],
+      "name": "getRoleMember",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getRoleMemberCount",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "grantRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "hasRole",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "addedValue",
+          "type": "uint256"
+        }
+      ],
+      "name": "increaseAllowance",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "mint",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "pause",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "paused",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "renounceRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "revokeRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes4",
+          "name": "interfaceId",
+          "type": "bytes4"
+        }
+      ],
+      "name": "supportsInterface",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "transfer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFrom",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "unpause",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+]

--- a/scripts/src/HandlerABI.json
+++ b/scripts/src/HandlerABI.json
@@ -1,0 +1,404 @@
+[
+    {
+      "inputs": [],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "worker",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "taskId",
+          "type": "bytes32"
+        }
+      ],
+      "name": "Claimed",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes",
+          "name": "recipient",
+          "type": "bytes"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "task",
+          "type": "string"
+        }
+      ],
+      "name": "Deposited",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "Paused",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "Unpaused",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "_activedTasks",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "name": "_depositRecords",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes",
+          "name": "recipient",
+          "type": "bytes"
+        },
+        {
+          "internalType": "string",
+          "name": "task",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "_workers",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "taskId",
+          "type": "bytes32"
+        }
+      ],
+      "name": "claim",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "claim_all",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes",
+          "name": "recipient",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "worker",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "taskId",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "string",
+          "name": "task",
+          "type": "string"
+        }
+      ],
+      "name": "deposit",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "worker",
+          "type": "address"
+        }
+      ],
+      "name": "getActivedTasks",
+      "outputs": [
+        {
+          "internalType": "bytes32[]",
+          "name": "",
+          "type": "bytes32[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "worker",
+          "type": "address"
+        }
+      ],
+      "name": "getLastActivedTask",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "taskId",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getTaskData",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "sender",
+              "type": "address"
+            },
+            {
+              "internalType": "contract IERC20",
+              "name": "token",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amount",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "recipient",
+              "type": "bytes"
+            },
+            {
+              "internalType": "string",
+              "name": "task",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct Handler.DepositInfo",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "paused",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "worker",
+          "type": "address"
+        }
+      ],
+      "name": "removeWorker",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "worker",
+          "type": "address"
+        }
+      ],
+      "name": "setWorker",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+]

--- a/scripts/src/config.poc5.json
+++ b/scripts/src/config.poc5.json
@@ -13,6 +13,13 @@
             "Moonbeam": "0x3a62a4980b952C92f4d4243c4A009336Ee0a26eB"
         }
     ],
+    "workers": [
+        "0xf243902011fdd1fb49b607740a4a5019da3a2116c3b39e63ccc70b1383627839",
+        "0x74cd4b3e1004398180d7c19a9e43375895b57fe3b131ad191ed5b761318c737b",
+        "0xf455d5ae94e19db3ff7e045602a449febdf713ec26941b9005da8f80ddbcab43",
+        "0x46a5c708bbf00a660c89d21d225943f9c975a1ccd11c2cb20401e1fd52e4d640",
+        "0xb48110e1d0de453d62e7e2508ad64152cc0b2a0a8c873d10cc5c54fb8a9f8175"
+    ],
     "chains": [
         {
             "Goerli": "https://goerli.infura.io/v3/6d61e7957c1c489ea8141e947447405b"

--- a/scripts/src/config.poc5.json
+++ b/scripts/src/config.poc5.json
@@ -2,7 +2,7 @@
     "node_wss_endpoint": "wss://poc5.phala.network/ws",
     "pruntine_endpoint": "https://poc5.phala.network/tee-api-1",
 
-    "executor_contract_id": "0x3f32e1d4d4704437121f909c9db9241143ca3eddb1c09656cf62521ee1d9389e",
+    "executor_contract_id": "0xa51e5bb5e5678bc5a7212931ae344c88df3b5d405b7a0323b05e7ad19cbe4514",
     "key_store_contract_id": "0x3a54c7576699d61ff1b5c57502d521a986b1f4bb83c4bca186ab2cb4a1a9769a",
 
     "handlers": [

--- a/scripts/src/config.poc5.json
+++ b/scripts/src/config.poc5.json
@@ -1,24 +1,27 @@
 {
-    "node_wss_endpoint": "wss://poc3.phala.network/ws",
+    "node_wss_endpoint": "wss://poc5.phala.network/ws",
     "pruntine_endpoint": "https://poc5.phala.network/tee-api-1",
 
-    "executor_contract_id": "",
-    "key_store_contract_id": "",
+    "executor_contract_id": "0xfa96630b1873229315c01b20b59320f4d692fef1b2dc52a5f4f817cf3c860ba6",
+    "key_store_contract_id": "0x3a54c7576699d61ff1b5c57502d521a986b1f4bb83c4bca186ab2cb4a1a9769a",
 
     "handlers": [
         {
-            "Goerli": "0x1234567890abcdef"
+            "Goerli": "0x7da7D95B07Ba569945e33e93063600c4A434FC6a"
         }
     ],
-    "Chains": [
+    "chains": [
         {
-            "Goerli": "123"
+            "Goerli": "https://goerli.infura.io/v3/6d61e7957c1c489ea8141e947447405b"
         },
         {
-            "Khala": "456"
+            "Poc5": "https://poc5.phala.network/rpc"
         },
         {
-            "Phala": "789"
+            "Khala": "https://khala-api.phala.network/rpc"
+        },
+        {
+            "Phala": "https://api.phala.network/rpc"
         }
     ]
 }

--- a/scripts/src/config.poc5.json
+++ b/scripts/src/config.poc5.json
@@ -2,7 +2,7 @@
     "node_wss_endpoint": "wss://poc5.phala.network/ws",
     "pruntine_endpoint": "https://poc5.phala.network/tee-api-1",
 
-    "executor_contract_id": "0xfa96630b1873229315c01b20b59320f4d692fef1b2dc52a5f4f817cf3c860ba6",
+    "executor_contract_id": "0x3f32e1d4d4704437121f909c9db9241143ca3eddb1c09656cf62521ee1d9389e",
     "key_store_contract_id": "0x3a54c7576699d61ff1b5c57502d521a986b1f4bb83c4bca186ab2cb4a1a9769a",
 
     "handlers": [

--- a/scripts/src/config.poc5.json
+++ b/scripts/src/config.poc5.json
@@ -1,0 +1,24 @@
+{
+    "node_wss_endpoint": "wss://poc3.phala.network/ws",
+    "pruntine_endpoint": "https://poc5.phala.network/tee-api-1",
+
+    "executor_contract_id": "",
+    "key_store_contract_id": "",
+
+    "handlers": [
+        {
+            "Goerli": "0x1234567890abcdef"
+        }
+    ],
+    "Chains": [
+        {
+            "Goerli": "123"
+        },
+        {
+            "Khala": "456"
+        },
+        {
+            "Phala": "789"
+        }
+    ]
+}

--- a/scripts/src/config.poc5.json
+++ b/scripts/src/config.poc5.json
@@ -8,6 +8,9 @@
     "handlers": [
         {
             "Goerli": "0x7da7D95B07Ba569945e33e93063600c4A434FC6a"
+        },
+        {
+            "Moonbeam": "0x3a62a4980b952C92f4d4243c4A009336Ee0a26eB"
         }
     ],
     "chains": [
@@ -22,6 +25,9 @@
         },
         {
             "Phala": "https://api.phala.network/rpc"
+        },
+        {
+            "Moonbeam": "https://rpc.api.moonbeam.network"
         }
     ]
 }

--- a/scripts/src/console.js
+++ b/scripts/src/console.js
@@ -1,0 +1,202 @@
+require('dotenv').config();
+
+const fs = require('fs');
+const { program } = require('commander');
+const { Decimal } = require('decimal.js');
+const BN = require('bn.js');
+const { ApiPromise, Keyring, WsProvider } = require('@polkadot/api');
+const { cryptoWaitReady } = require('@polkadot/util-crypto');
+const ethers = require('ethers')
+const PhalaSdk = require('@phala/sdk')
+const PhalaSDKTypes = PhalaSdk.types
+const KhalaTypes = require('@phala/typedefs').khalaDev
+const { loadContractFile, createContract } = require('./utils');
+
+const ERC20ABI = require('./ERC20ABI.json')
+const HandlerABI = require('./HandlerABI.json')
+
+function run(afn) {
+    function runner(...args) {
+        afn(...args)
+            .then(process.exit)
+            .catch(console.error)
+            .finally(() => process.exit(-1));
+    };
+    return runner;
+}
+
+function useConfig() {
+    const { config } = program.opts();
+    return JSON.parse(fs.readFileSync(config, 'utf8'));
+}
+
+function useChainEndpoint(config, chainName) {
+    const chain = config.chains.find(chain => Object.keys(chain)[0] === chainName);
+    const endpoint = chain && Object.values(chain)[0];
+    return endpoint;
+}
+
+function useChainType(chain) {
+    if (['ethereum', 'goerli', 'moonbeam', 'astar'].includes(chain)) {
+        return 'Evm';
+    } else if (['khala', 'phala', 'acala'].includes(chain)) {
+        return 'Sub';
+    } else {
+        throw new Error(`Unrecognized chain type: ${chain}`);
+    }
+}
+
+async function useApi(endpoint) {
+    const wsProvider = new WsProvider(endpoint);
+    const api = await ApiPromise.create({
+        provider: wsProvider,
+        types: {
+            ...KhalaTypes,
+            ...PhalaSDKTypes,
+        },
+    });
+    return api;
+}
+
+async function useCert(uri) {
+    await cryptoWaitReady();
+    const keyring = new Keyring({ type: 'sr25519' })
+    const account = keyring.addFromUri(uri)
+    return await PhalaSdk.signCertificate({
+        api: nodeApi,
+        pair: account,
+    });
+}
+
+function useEtherProvider(endpoint) {
+    return new ethers.providers.JsonRpcProvider(endpoint)
+}
+
+function useERC20Token(provider, token) {
+    return new ethers.Contract(
+        token,
+        ERC20ABI,
+        provider
+    )
+}
+
+function useEvmHandler(provider, handler) {
+    return new ethers.Contract(
+        handler,
+        HandlerABI,
+        provider
+    )
+}
+
+async function useExecutor(api, pruntime_endpoint, contract_id) {
+    const contract = loadContractFile(
+        path.join(__dirname, '../../target/ink/index_executor/index_executor.contract'),
+    )
+    console.log(`Connected to node, create contract object`)
+    return await createContract(api, pruntime_endpoint, contract, contract_id)
+}
+
+program
+    .option('--config <path>', 'config that contains contract and node informations', process.env.CONFIG || 'config.json')
+    .option('--uri <path>', 'the account URI use to sign cert', process.env.URI || '//Alice')
+
+
+const executor = program
+.command('executor')
+.description('inDEX executor');
+
+const hander = program
+.command('hander')
+.description('inDEX handler contract/pallet');
+
+const task = program
+.command('task')
+.description('inDEX task inspector');
+
+const worker = program
+.command('worker')
+.description('inDEX worker account management');
+
+worker
+    .command('list')
+    .description('list worker accounts')
+    .option('--worker <worker>', 'worker sr25519 public key', null)
+    .action(run(async () => {
+        let { uri } = program.opts();
+        let config = useConfig();
+        let api = await useApi(config.node_wss_endpoint);
+        let executor = await useExecutor(api, config.pruntine_endpoint, config.executor_contract_id);
+        let cert = await useCert(uri);
+        let workers = await executor.query.getWorkerAccounts(cert,
+            {},
+        );
+        if (opt.worker !== null) {
+            console.log(workers.find(worker => worker.toLowerCase() === opt.worker.toLowerCase()));
+        } else {
+            console.log(workers);
+        }
+    }));
+
+worker
+    .command('approve')
+    .description('approve ERC20 for specific asset')
+    .requiredOption('--worker <worker>', 'worker H160 address', null)
+    .requiredOption('--chain <chain>', 'chain name', null)
+    .requiredOption('--token <token>', 'ERC20 token contract address', null)
+    .requiredOption('--spender <spender>', 'spender H160 address', null)
+    .requiredOption('--amount <amount>', 'the amount set to allowance', null)
+
+    .action(run(async () => {
+        let { uri } = program.opts();
+        let config = useConfig();
+        let api = await useApi(config.node_wss_endpoint);
+        let executor = await useExecutor(api, config.pruntine_endpoint, config.executor_contract_id);
+        let cert = await useCert(uri);
+
+        console.log(`Call Executor::worker_approve to approve ERC20 for specific asset`);
+        let queryRecipient = await executor.query.workerApprove(cert,
+            {},
+            opt.worker,
+            opt.chain.charAt(0).toUpperCase() + opt.chain.slice(1).toLowerCase(),
+            opt.token,
+            opt.spender,
+            opt.amount,
+        );
+        console.log(`Query recipient: ${queryRecipient}`);
+    }));
+
+worker
+    .command('balance')
+    .description('get the firee blance of the worker account on specific chain')
+    .requiredOption('--chain <chain>', 'Chain name', null)
+    .requiredOption('--asset <asset>', 'Asset location<smart contract address for encoded multilocation>', null)
+    .requiredOption('--worker <worker_account>', 'Worker account', null)
+    .action(run (async (opt) => {
+        if (opt.chain) {
+            let config = useConfig();
+            let endpoint = useChainEndpoint(config, opt.chain.toLowerCase());
+            if (useChainType(opt.chain.toLowerCase()) === 'Evm') {
+                let provider = useEtherProvider(endpoint);
+                if (opt.asset === null) {
+                    console.log(await provider.getBalance(opt.worker));
+                } else {
+                    let token = useERC20Token(provider, opt.asset);
+                    console.log(await token.balanceOf(opt.worker));
+                }
+            } else {    // Sub
+                let api = await useApi(endpoint);
+                if (opt.asset === null) {
+                    const accountData = await api.query.system.account(opt.worker);
+                    const freeBalance = accountData.data.free.toString();
+                    console.log(freeBalance);
+                } else {
+                    throw new Error(`Not support balance query for asset: ${opt.asset}`);
+                }
+            }
+        } else {
+            throw new Error("Please provide the chain name");
+        }
+    }));
+
+
+program.parse(process.argv);

--- a/scripts/src/console.js
+++ b/scripts/src/console.js
@@ -99,20 +99,85 @@ async function useExecutor(api, pruntime_endpoint, contract_id) {
 
 program
     .option('--config <path>', 'config that contains contract and node informations', process.env.CONFIG || 'config.json')
-    .option('--uri <path>', 'the account URI use to sign cert', process.env.URI || '//Alice')
-
+    .option('--uri <URI>', 'the account URI use to sign cert', process.env.URI || '//Alice')
 
 const executor = program
 .command('executor')
 .description('inDEX executor');
 
+executor
+    .command('account')
+    .description('show executor account information')
+    .option('--balance <worker>', 'worker sr25519 public key', null)
+    .action(run(async (opt) => {
+        // TODO
+    }));
+
+executor
+    .command('balance')
+    .description('return executor account balance on anchor chain')
+    .action(run(async (opt) => {
+        // TODO
+    }));
+
+executor
+    .command('worker')
+    .description('return worker accounts of the executor')
+    .option('--free', 'list worker account that currently not been allocated', false)
+    .action(run(async (opt) => {
+        // TODO
+    }));
+
+executor
+    .command('task')
+    .description('return tasks id list that currently running')
+    .action(run(async (opt) => {
+        // TODO
+    }));
+
+const task = program
+    .command('task')
+    .description('inDEX task inspector');
+    
+task
+    .command('list')
+    .description('Return tasks existing in local cache')
+    .option('--id <taskId>', 'task id', null)
+    .action(run(async (opt) => {
+        // TODO
+        // If id is not set, return all tasks existing in local cache
+    }));
+
 const hander = program
 .command('hander')
 .description('inDEX handler contract/pallet');
 
-const task = program
-.command('task')
-.description('inDEX task inspector');
+hander
+    .command('list')
+    .description('list handler account deployed on chains')
+    .option('--chain <chain>', 'chain name', null)
+    .action(run(async (opt) => {
+        // TODO
+        // If chain not given, list handker on all supported chains
+    }));
+
+hander
+    .command('task')
+    .description('list actived tasks that belong to the given worker')
+    .requiredOption('--chain <chain>', 'chain name', null)
+    .requiredOption('--worker <worker>', 'woker H160 address on EVM chain, sr25519 public key on substrate chain', null)
+    .action(run(async (opt) => {
+        // TODO
+    }));
+
+hander
+    .command('balance')
+    .description('Return balance of the given asset that handler holds')
+    .requiredOption('--chain <chain>', 'chain name', null)
+    .requiredOption('--asset <asset>', 'asset H160 address on EVM chain, encoded MultiLocation on substrate chain', null)
+    .action(run(async (opt) => {
+        // TODO
+    }));
 
 const worker = program
 .command('worker')
@@ -142,7 +207,7 @@ worker
 worker
     .command('approve')
     .description('approve ERC20 for specific asset')
-    .requiredOption('--worker <worker>', 'worker H160 address', null)
+    .requiredOption('--worker <worker>', 'worker sr25519 public key', null)
     .requiredOption('--chain <chain>', 'chain name', null)
     .requiredOption('--token <token>', 'ERC20 token contract address', null)
     .requiredOption('--spender <spender>', 'spender H160 address', null)

--- a/scripts/src/scheduler.js
+++ b/scripts/src/scheduler.js
@@ -7,36 +7,13 @@ const KhalaTypes = require('@phala/typedefs').khalaDev
 const fs = require('fs')
 const path = require('path')
 
+const { loadContractFile, createContract } = require('utils');
+
 const NODE_ENDPOINT = 'wss://poc5.phala.network/ws'
 const PRUNTIME_ENDPOINT = 'https://poc5.phala.network/tee-api-1'
 const CONTRACT_ID = '0x90a1cbf2a00c76e16d53cd3568c639eacbb30076138cf38270e4673f37c6a3ff'
 const EXE_WORKER = '0x2eaaf908adda6391e434ff959973019fb374af1076edd4fec55b5e6018b1a955'
 const SOURCE = 'Moonbeam'
-
-function loadContractFile(contractFile) {
-    const metadata = JSON.parse(fs.readFileSync(contractFile, 'utf8'))
-    const constructor = metadata.V3.spec.constructors.find(
-      c => c.label == 'default',
-    ).selector
-    const name = metadata.contract.name
-    const wasm = metadata.source.wasm
-    return { wasm, metadata, constructor, name }
-}
-
-async function createContract(api, pruntimeUrl, contract, contractID) {
-    const { api: workerApi } = await PhalaSdk.create({
-      api,
-      baseURL: pruntimeUrl,
-      contractId: contractID,
-      autoDeposit: true,
-    })
-    const contractApi = new ContractPromise(
-      workerApi,
-      contract.metadata,
-      contractID,
-    )
-    return contractApi
-}
 
 async function loop_task() {
     return new Promise(async (_resolve, reject) => {
@@ -94,5 +71,3 @@ async function main() {
         console.error(`task run failed: ${err}`)
     }
 }
-
-main()

--- a/scripts/src/scheduler.js
+++ b/scripts/src/scheduler.js
@@ -1,18 +1,16 @@
 require('console-stamp')(console, '[HH:MM:ss.l]')
-const { ContractPromise } = require('@polkadot/api-contract')
 const { ApiPromise, WsProvider, Keyring } = require('@polkadot/api')
 const PhalaSdk = require('@phala/sdk')
 const PhalaSDKTypes = PhalaSdk.types
 const KhalaTypes = require('@phala/typedefs').khalaDev
-const fs = require('fs')
 const path = require('path')
 
-const { loadContractFile, createContract } = require('utils');
+const { loadContractFile, createContract } = require('./utils');
 
 const NODE_ENDPOINT = 'wss://poc5.phala.network/ws'
 const PRUNTIME_ENDPOINT = 'https://poc5.phala.network/tee-api-1'
-const CONTRACT_ID = '0x90a1cbf2a00c76e16d53cd3568c639eacbb30076138cf38270e4673f37c6a3ff'
-const EXE_WORKER = '0x2eaaf908adda6391e434ff959973019fb374af1076edd4fec55b5e6018b1a955'
+const CONTRACT_ID = '0x73764ed5e41d6d702a8ba80475a4d46a9597876b055ac6866e05a4cfee2b9db6'
+const EXE_WORKER = '0xf455d5ae94e19db3ff7e045602a449febdf713ec26941b9005da8f80ddbcab43'
 const SOURCE = 'Moonbeam'
 
 async function loop_task() {
@@ -50,16 +48,16 @@ async function loop_task() {
                 {},
                 {'Fetch': [SOURCE, EXE_WORKER]}
             )
-        }, 30000)
+        }, 15000)
 
         // Trigger task executing every 10 seconds
-        setInterval(async () => {
-            console.log(`🐌Trigger task executing`)
-            await executor.query.run(certAlice,
-                {},
-                'Execute'
-            )
-        }, 10000)
+        // setInterval(async () => {
+        //     console.log(`🐌Trigger task executing`)
+        //     await executor.query.run(certAlice,
+        //         {},
+        //         'Execute'
+        //     )
+        // }, 10000)
     })
 }
 
@@ -71,3 +69,5 @@ async function main() {
         console.error(`task run failed: ${err}`)
     }
 }
+
+main()

--- a/scripts/src/utils.js
+++ b/scripts/src/utils.js
@@ -1,11 +1,12 @@
 const fs = require('fs')
 const { ApiPromise, WsProvider, Keyring } = require('@polkadot/api')
+const { ContractPromise } = require('@polkadot/api-contract')
 const PhalaSdk = require('@phala/sdk')
 const PhalaSDKTypes = PhalaSdk.types
 
 function loadContractFile(contractFile) {
     const metadata = JSON.parse(fs.readFileSync(contractFile, 'utf8'))
-    const constructor = metadata.V3.spec.constructors.find(
+    const constructor = metadata.spec.constructors.find(
       c => c.label == 'default',
     ).selector
     const name = metadata.contract.name

--- a/scripts/src/utils.js
+++ b/scripts/src/utils.js
@@ -1,0 +1,34 @@
+const fs = require('fs')
+const { ApiPromise, WsProvider, Keyring } = require('@polkadot/api')
+const PhalaSdk = require('@phala/sdk')
+const PhalaSDKTypes = PhalaSdk.types
+
+function loadContractFile(contractFile) {
+    const metadata = JSON.parse(fs.readFileSync(contractFile, 'utf8'))
+    const constructor = metadata.V3.spec.constructors.find(
+      c => c.label == 'default',
+    ).selector
+    const name = metadata.contract.name
+    const wasm = metadata.source.wasm
+    return { wasm, metadata, constructor, name }
+}
+
+async function createContract(api, pruntimeUrl, contract, contractID) {
+    const { api: workerApi } = await PhalaSdk.create({
+      api,
+      baseURL: pruntimeUrl,
+      contractId: contractID,
+      autoDeposit: true,
+    })
+    const contractApi = new ContractPromise(
+      workerApi,
+      contract.metadata,
+      contractID,
+    )
+    return contractApi
+}
+
+module.exports = {
+    loadContractFile,
+    createContract,
+}


### PR DESCRIPTION
Three main stuff contained in this PR:

**Fixed the worker allocation issue during task initialization**
Now, the worker that is allocated to a task is explicitly specified by the client, when `deposit` task to the source chain, the worker account will be saved along with the task (which is set by the client simply). Then the engine initializes the task, if it found the  worker is `busy` according to rollup storage, initialization will fail

**Introduce new contract KeyStore**
This contract is dedicated to derive&keep workers' private keys. Only a whitelist executor contract can get private keys from it. Now we set the `key_store` account on the executor `config` method, which will trigger the private key import. This design is good to make the engine stateless and upgradable.

**CLI**
We have introduced serval CLI commands to help config and debug the contract. Most of them are left as  TODO, which can be implemented in the future. The code is under `scripts/console.js`
