### PR TITLE
Keep task data in db when finished

### DIFF
--- a/contracts/index_executor/src/task.rs
+++ b/contracts/index_executor/src/task.rs
@@ -297,26 +297,22 @@ impl Task {
             .read_storage::<Vec<TaskId>>(b"pending_tasks")?
             .ok_or("StorageNotConfigured")?;
 
-        if let Some((_, task_doc)) = client.read_storage::<Task>(&self.id)? {
-            if let Some(idx) = pending_tasks.iter().position(|id| *id == self.id) {
-                // Remove from pending tasks queue
-                pending_tasks.remove(idx);
-                // Recycle worker account
-                free_accounts.push(self.worker);
-                // Delete task data
-                client.remove_storage(self.id.as_ref(), task_doc)?;
-            }
-            client.update_storage(
-                b"free_accounts".as_ref(),
-                &free_accounts.encode(),
-                free_accounts_doc,
-            )?;
-            client.update_storage(
-                b"pending_tasks".as_ref(),
-                &pending_tasks.encode(),
-                pending_tasks_doc,
-            )?;
+        if let Some(idx) = pending_tasks.iter().position(|id| *id == self.id) {
+            // Remove from pending tasks queue
+            pending_tasks.remove(idx);
+            // Recycle worker account
+            free_accounts.push(self.worker);
         }
+        client.update_storage(
+            b"free_accounts".as_ref(),
+            &free_accounts.encode(),
+            free_accounts_doc,
+        )?;
+        client.update_storage(
+            b"pending_tasks".as_ref(),
+            &pending_tasks.encode(),
+            pending_tasks_doc,
+        )?;
 
         Ok(())
     }


### PR DESCRIPTION
Considering we save task data in Google could database, there shouldn't be too many resource problems. Keep task data in DB after finished is friendly for SDK or client to check task execution result in the future